### PR TITLE
Adding new plugins

### DIFF
--- a/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
@@ -49,18 +49,22 @@ import org.mastodon.mamut.plugin.MamutPlugin;
 import org.mastodon.mamut.plugin.MamutPluginAppModel;
 import org.mastodon.mamut.project.MamutProject;
 import org.mastodon.mamut.tomancak.compact_lineage.CompactLineageFrame;
+import org.mastodon.mamut.tomancak.export.ExportCounts;
+import org.mastodon.mamut.tomancak.export.LineageLengthExporter;
 import org.mastodon.mamut.tomancak.export.MakePhyloXml;
 import org.mastodon.mamut.tomancak.merging.Dataset;
 import org.mastodon.mamut.tomancak.merging.MergeDatasets;
 import org.mastodon.mamut.tomancak.merging.MergingDialog;
 import org.mastodon.mamut.tomancak.sort_tree.FlipDescendants;
 import org.mastodon.mamut.tomancak.sort_tree.SortTreeDialog;
+import org.mastodon.mamut.tomancak.spots.FilterOutSolists;
 import org.mastodon.mamut.tomancak.spots.InterpolateMissingSpots;
 import org.mastodon.model.SelectionModel;
 import org.mastodon.ui.keymap.CommandDescriptionProvider;
 import org.mastodon.ui.keymap.CommandDescriptions;
 import org.mastodon.ui.keymap.KeyConfigContexts;
 import org.scijava.AbstractContextual;
+import org.scijava.command.CommandService;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.behaviour.util.AbstractNamedAction;
 import org.scijava.ui.behaviour.util.Actions;
@@ -76,6 +80,9 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String LABEL_SELECTED_SPOTS = "[tomancak] label selected spots";
 	private static final String COMPACT_LINEAGE_VIEW = "[tomancak] show compact lineage";
 	private static final String SORT_TREE = "[tomancak] sort lineage tree";
+	private static final String REMOVE_SOLISTS_SPOTS = "[tomancak] remove solists spots";
+	private static final String EXPORTS_LINEAGE_LENGTHS = "[tomancak] export lineage lengths";
+	private static final String EXPORTS_SPOTS_COUNTS = "[tomancak] export spots counts";
 	private static final String MERGE_PROJECTS = "[tomancak] merge projects";
 	private static final String TWEAK_DATASET_PATH = "[tomancak] fix project image path";
 
@@ -86,6 +93,9 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String[] LABEL_SELECTED_SPOTS_KEYS = { "F2" };
 	private static final String[] COMPACT_LINEAGE_VIEW_KEYS = { "not mapped" };
 	private static final String[] SORT_TREE_KEYS = { "not mapped" };
+	private static final String[] REMOVE_SOLISTS_SPOTS_KEYS = { "not mapped" };
+	private static final String[] EXPORTS_LINEAGE_LENGTHS_KEYS = { "not mapped" };
+	private static final String[] EXPORTS_SPOTS_COUNTS_KEYS = { "not mapped" };
 	private static final String[] MERGE_PROJECTS_KEYS = { "not mapped" };
 	private static final String[] TWEAK_DATASET_PATH_KEYS = { "not mapped" };
 
@@ -100,6 +110,9 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		menuTexts.put( LABEL_SELECTED_SPOTS, "Label Selected Spots" );
 		menuTexts.put( COMPACT_LINEAGE_VIEW, "Show Compact Lineage" );
 		menuTexts.put( SORT_TREE, "Sort Lineage Tree" );
+		menuTexts.put( REMOVE_SOLISTS_SPOTS, "Remove Spots Solists" );
+		menuTexts.put( EXPORTS_LINEAGE_LENGTHS, "Export Lineage Lengths" );
+		menuTexts.put( EXPORTS_SPOTS_COUNTS, "Export Spots Counts" );
 		menuTexts.put( MERGE_PROJECTS, "Merge Two Projects" );
 		menuTexts.put( TWEAK_DATASET_PATH, "Fix Image Path" );
 	}
@@ -125,6 +138,9 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 			descriptions.add( LABEL_SELECTED_SPOTS, LABEL_SELECTED_SPOTS_KEYS, "Set label for all selected spots." );
 			descriptions.add( COMPACT_LINEAGE_VIEW, COMPACT_LINEAGE_VIEW_KEYS, "Show compact representation of the lineage tree.");
 			descriptions.add( SORT_TREE, SORT_TREE_KEYS, "Sort selected node according to tagged anchors.");
+			descriptions.add( REMOVE_SOLISTS_SPOTS, REMOVE_SOLISTS_SPOTS_KEYS, "Finds and removes isolated spots from the lineage, based on conditions." );
+			descriptions.add( EXPORTS_LINEAGE_LENGTHS, EXPORTS_LINEAGE_LENGTHS_KEYS, "Exports lineage lengths into CSV-like files to be imported in data processors." );
+			descriptions.add( EXPORTS_SPOTS_COUNTS, EXPORTS_SPOTS_COUNTS_KEYS, "Exports counts of spots into CSV-like files to be imported in data processors." );
 			descriptions.add( MERGE_PROJECTS, MERGE_PROJECTS_KEYS, "Merge two Mastodon projects into one." );
 			descriptions.add( TWEAK_DATASET_PATH, TWEAK_DATASET_PATH_KEYS, "Allows to insert new path to the BDV data and whether it is relative or absolute." );
 		}
@@ -144,6 +160,12 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 
 	private final AbstractNamedAction sortTreeAction;
 
+	private final AbstractNamedAction removeSolistsAction;
+
+	private final AbstractNamedAction exportLineageLengthsAction;
+
+	private final AbstractNamedAction exportSpotsCountsAction;
+
 	private final AbstractNamedAction mergeProjectsAction;
 
 	private final AbstractNamedAction tweakDatasetPathAction;
@@ -159,6 +181,9 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		labelSelectedSpotsAction = new RunnableAction( LABEL_SELECTED_SPOTS, this::labelSelectedSpots );
 		lineageTreeViewAction = new RunnableAction( COMPACT_LINEAGE_VIEW, this::showLineageView );
 		sortTreeAction = new RunnableAction( SORT_TREE, this::sortTree );
+		removeSolistsAction = new RunnableAction( REMOVE_SOLISTS_SPOTS, this::filterOutSolists );
+		exportLineageLengthsAction = new RunnableAction( EXPORTS_LINEAGE_LENGTHS, this::exportLengths );
+		exportSpotsCountsAction = new RunnableAction( EXPORTS_SPOTS_COUNTS, this::exportCounts );
 		mergeProjectsAction = new RunnableAction( MERGE_PROJECTS, this::mergeProjects );
 		tweakDatasetPathAction = new RunnableAction( TWEAK_DATASET_PATH, this::tweakDatasetPath );
 		updateEnabledActions();
@@ -181,10 +206,13 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 								item( COMPACT_LINEAGE_VIEW )),
 						menu( "Trees Management",
 								item( LABEL_SELECTED_SPOTS ),
+								item( REMOVE_SOLISTS_SPOTS ),
 								item( INTERPOLATE_SPOTS ),
 								item( FLIP_DESCENDANTS ),
 								item( SORT_TREE )),
 						menu( "Exports",
+								item( EXPORTS_LINEAGE_LENGTHS ),
+								item( EXPORTS_SPOTS_COUNTS ),
 								item( EXPORT_PHYLOXML )) ),
 				menu( "File",
 						item( TWEAK_DATASET_PATH ),
@@ -207,6 +235,9 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		actions.namedAction( labelSelectedSpotsAction, LABEL_SELECTED_SPOTS_KEYS );
 		actions.namedAction( lineageTreeViewAction, COMPACT_LINEAGE_VIEW_KEYS );
 		actions.namedAction( sortTreeAction, SORT_TREE_KEYS );
+		actions.namedAction( removeSolistsAction, REMOVE_SOLISTS_SPOTS_KEYS );
+		actions.namedAction( exportLineageLengthsAction, EXPORTS_LINEAGE_LENGTHS_KEYS );
+		actions.namedAction( exportSpotsCountsAction, EXPORTS_SPOTS_COUNTS_KEYS );
 		actions.namedAction( mergeProjectsAction, MERGE_PROJECTS_KEYS );
 		actions.namedAction( tweakDatasetPathAction, TWEAK_DATASET_PATH_KEYS );
 	}
@@ -221,6 +252,9 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		labelSelectedSpotsAction.setEnabled( appModel != null );
 		lineageTreeViewAction.setEnabled( appModel != null );
 		sortTreeAction.setEnabled( appModel != null );
+		removeSolistsAction.setEnabled( appModel != null );
+		exportLineageLengthsAction.setEnabled( appModel != null );
+		exportSpotsCountsAction.setEnabled( appModel != null );
 		mergeProjectsAction.setEnabled( appModel != null );
 		tweakDatasetPathAction.setEnabled( appModel != null );
 	}
@@ -300,6 +334,27 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		CompactLineageFrame frame =
 			new CompactLineageFrame(pluginAppModel.getAppModel());
 		frame.setVisible(true);
+	}
+
+	private void filterOutSolists()
+	{
+		this.getContext().getService(CommandService.class).run(
+				FilterOutSolists.class, true,
+				"appModel", pluginAppModel.getAppModel());
+	}
+
+	private void exportLengths()
+	{
+		this.getContext().getService(CommandService.class).run(
+				LineageLengthExporter.class, true,
+				"appModel", pluginAppModel.getAppModel());
+	}
+
+	private void exportCounts()
+	{
+		this.getContext().getService(CommandService.class).run(
+				ExportCounts.class, true,
+				"appModel", pluginAppModel.getAppModel());
 	}
 
 	private MergingDialog mergingDialog;

--- a/src/main/java/org/mastodon/mamut/tomancak/export/ExportCounts.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/export/ExportCounts.java
@@ -1,0 +1,112 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2021, 2022, Vladimír Ulman
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.mastodon.mamut.tomancak.export;
+
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.MamutAppModel;
+import org.mastodon.mamut.tomancak.util.SpotsIterator;
+import org.scijava.ItemVisibility;
+import org.scijava.command.Command;
+import org.scijava.log.Logger;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.widget.FileWidget;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.IOException;
+
+@Plugin( type = Command.class, name = "Export spots counts per lineage per time point" )
+public class ExportCounts implements Command
+{
+	@Parameter(visibility = ItemVisibility.MESSAGE)
+	private final String selectionInfoMsg = "...also of only selected sub-trees.";
+
+	@Parameter(label = "Original time point values:",
+			description = "If unchecked, time becomes relative to respective lineage root and will thus start always from zero.")
+	boolean reportAbsoluteTime = false;
+
+	@Parameter(label = "Delimiting character:",
+			description = "Separator of columns (between time and count) in the exported files.")
+	String delim = ",";
+
+	@Parameter(label = "Filenames prefix:",
+			description = "Prefix used for every name of the exported files. Leave empty to use no prefix.")
+	String fileNamesPrefix = "";
+
+	@Parameter(label = "Output directory:", style = FileWidget.DIRECTORY_STYLE)
+	File outputDirectory;
+
+	@Parameter(persist = false)
+	private MamutAppModel appModel;
+
+	@Parameter
+	private LogService logService;
+
+	@Override
+	public void run()
+	{
+		final Logger loggerRoots = logService.subLogger("Counts exporter...");
+		ss = new SpotsIterator(appModel, loggerRoots);
+
+		if (appModel.getSelectionModel().isEmpty())
+			ss.visitRootsFromEntireGraph(this::processOneLineage);
+		else
+			ss.visitRootsFromSelection(this::processOneLineage);
+	}
+
+	SpotsIterator ss;
+	final Map<Integer,Integer> tpToCnts = new HashMap<>(2000);
+
+	void processOneLineage(final Spot rootSpot)
+	{
+		tpToCnts.clear();
+		final int refTP = reportAbsoluteTime ? 0 : rootSpot.getTimepoint();
+		ss.visitDownstreamSpots( rootSpot,
+				s -> tpToCnts.put(s.getTimepoint()-refTP, 1+tpToCnts.getOrDefault(s.getTimepoint()-refTP,0)) );
+		writeCSV(rootSpot.getLabel());
+	}
+
+	void writeCSV(final String treeLabel)
+	{
+		final String filename = outputDirectory.getAbsolutePath()+File.separator+fileNamesPrefix+treeLabel+".csv";
+		logService.info("Writing file: "+filename);
+		try ( PrintWriter file = new PrintWriter(new FileWriter(filename)) )
+		{
+			for (Map.Entry<Integer,Integer> tp : tpToCnts.entrySet())
+				file.println(tp.getKey()+delim+tp.getValue());
+		} catch (IOException e) {
+			logService.error("Error writing a file "+filename+":"+e.getMessage());
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/export/LineageLengthExporter.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/export/LineageLengthExporter.java
@@ -1,0 +1,199 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2021, 2022, Vladimír Ulman
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.mastodon.mamut.tomancak.export;
+
+import org.mastodon.collection.*;
+import org.mastodon.ui.util.FileChooser;
+import org.mastodon.mamut.MamutAppModel;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.Link;
+
+import org.scijava.ItemVisibility;
+import org.scijava.command.Command;
+import org.scijava.command.DynamicCommand;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+
+@Plugin( type = Command.class, name = "Export lineage as lengths between divisions" )
+public class LineageLengthExporter extends DynamicCommand
+{
+	@Parameter(persist = false)
+	private MamutAppModel appModel;
+
+	@Parameter(label = "Do not report anything before this time point:",
+	           min = "0")
+	private int timePointFrom = 0;
+
+	@Parameter(label = "Do not report anything beyond this time point:",
+	           description = "Value of -1 means no limit.", min = "-1")
+	private int timePointTill = -1;
+
+	@Parameter(label = "Time step, physical time between time points:")
+	private float timeStep = 90.0f;
+
+	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false, required = false)
+	private String fileOpenInfo = "The plugin will additionally ask for file to save the lineage.";
+
+	/** the main workhorse */
+	public void run()
+	{
+		final String columnSep = "\t";
+		if (timePointTill == -1) timePointTill = appModel.getMaxTimepoint();
+		try {
+
+		//borrow a spot "placeholder" (and return it at the very end!)
+		final Spot parent = appModel.getModel().getGraph().vertices().createRef();
+		final Spot rRef = appModel.getModel().getGraph().vertices().createRef();
+		final Spot sRef = appModel.getModel().getGraph().vertices().createRef();
+		final Link lRef = appModel.getModel().getGraph().edges().createRef();
+
+		//finds the starting spot
+		appModel.getFocusModel().getFocusedVertex( parent );
+		System.out.println("Going to export the tree from the spot: "+parent.getLabel()
+		                  +" (timepoint "+parent.getTimepoint()+")");
+
+		final File oFile = FileChooser.chooseFile(null,"LineageOf_"+parent.getLabel()+".txt", null, "Save the lineage as...", FileChooser.DialogType.SAVE );
+		final BufferedWriter jout = oFile != null? new BufferedWriter(new FileWriter(oFile)) : null;
+
+		//sets up the sweeping data structures
+		//timepoint to spot, sorted accoring to timepoints (and position in trackScheme for the same timepoints)
+		final RefList<Spot> discoveredDivPoints
+			= RefCollections.createRefList(appModel.getModel().getGraph().vertices());
+
+		//spot to spot
+		final RefRefMap< Spot, Spot > trackStarters
+			= RefMaps.createRefRefMap(appModel.getModel().getGraph().vertices(), 500);
+
+		//starts the export by moving to the earliest division point (for which we don't have its starter)
+		if (browseDownstreamTillNextDivisionEvent(parent,sRef,lRef) > 1) discoveredDivPoints.add( parent );
+
+		while (discoveredDivPoints.size() > 0)
+		{
+			//get the oldest division point on the list
+			discoveredDivPoints.remove( 0, parent );
+
+			if (trackStarters.containsKey( parent ))
+			{
+				//report this track
+				final Spot starter = trackStarters.get( parent );
+
+				//only if it fits the timepoint range
+				if (starter.getTimepoint() >= timePointFrom && parent.getTimepoint() <= timePointTill)
+				{
+					final String msg = starter.getLabel()+columnSep
+					                 + starter.getTimepoint()+columnSep
+					                 + parent.getLabel()+columnSep
+					                 + parent.getTimepoint()+columnSep
+					                 + (parent.getTimepoint()-starter.getTimepoint())+columnSep
+					                 + (parent.getTimepoint()-starter.getTimepoint())*timeStep;
+					if (jout != null)
+					{
+						jout.write( msg );
+						jout.newLine();
+					}
+					System.out.println( msg );
+				}
+			}
+
+			//parent is for sure a division point,
+			//enumerate its daughters and enlist them
+			for (int n=0; n < parent.incomingEdges().size(); ++n)
+			{
+				parent.incomingEdges().get(n, lRef).getSource( rRef );
+				if (rRef.getTimepoint() > parent.getTimepoint() && browseDownstreamTillNextDivisionEvent( rRef, sRef, lRef ) > 1)
+				{
+					enlistSpot( discoveredDivPoints, rRef );
+					trackStarters.put( rRef, parent );
+				}
+			}
+			for (int n=0; n < parent.outgoingEdges().size(); ++n)
+			{
+				parent.outgoingEdges().get(n, lRef).getTarget( rRef );
+				if (rRef.getTimepoint() > parent.getTimepoint() && browseDownstreamTillNextDivisionEvent( rRef, sRef, lRef ) > 1)
+				{
+					enlistSpot( discoveredDivPoints, rRef );
+					trackStarters.put( rRef, parent );
+				}
+			}
+		}
+
+		appModel.getModel().getGraph().edges().releaseRef( lRef );
+		appModel.getModel().getGraph().vertices().releaseRef( sRef );
+		appModel.getModel().getGraph().vertices().releaseRef( rRef );
+		appModel.getModel().getGraph().vertices().releaseRef( parent );
+
+		if (jout != null)
+		{
+			jout.flush();
+			jout.close();
+		}
+
+		} catch (IOException e) {
+			System.out.println("Some file writing problem: "+e.getMessage());
+		}
+	}
+
+	private void enlistSpot(final RefList< Spot > list, final Spot cell)
+	{
+		int i = 0;
+		while (i < list.size() && list.get(i).getTimepoint() <= cell.getTimepoint()) ++i;
+		list.add(i,cell);
+	}
+
+	/** moves the cell downstream until the cell has 0 or 2 or more descendants,
+	    and returns the number of discovered descendants;
+	    r(running)Ref is the one that's gonna be moved downstream,
+	    sRef anf lRef are additional spot and link aux variables to facilitate the search */
+	private int browseDownstreamTillNextDivisionEvent(final Spot rRef, final Spot sRef, final Link lRef)
+	{
+		int edgeCnt;
+		do {
+			edgeCnt = 0;
+			for (int n=0; n < rRef.incomingEdges().size(); ++n)
+			{
+				rRef.incomingEdges().get(n, lRef).getSource( sRef );
+				if (sRef.getTimepoint() > rRef.getTimepoint()) ++edgeCnt;
+			}
+			for (int n=0; n < rRef.outgoingEdges().size(); ++n)
+			{
+				rRef.outgoingEdges().get(n, lRef).getTarget( sRef );
+				if (sRef.getTimepoint() > rRef.getTimepoint()) ++edgeCnt;
+			}
+
+			if (edgeCnt == 1) rRef.refTo( sRef );
+		} while (edgeCnt == 1);
+
+		return edgeCnt;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/spots/FilterOutSolists.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/spots/FilterOutSolists.java
@@ -1,0 +1,86 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2021, 2022, Vladimír Ulman
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.mastodon.mamut.tomancak.spots;
+
+import org.apache.commons.lang.StringUtils;
+import org.mastodon.collection.RefList;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.collection.ref.RefArrayList;
+import org.mastodon.mamut.tomancak.util.SpotsIterator;
+import org.mastodon.mamut.MamutAppModel;
+import org.scijava.ItemVisibility;
+import org.scijava.command.Command;
+import org.scijava.log.Logger;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = Command.class, name = "Filter lineage and remove solists spots" )
+public class FilterOutSolists implements Command
+{
+	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false, required = false)
+	final String hintMsg = "Solist has no ancestors and no descendants, plus the conditions below:";
+
+	@Parameter
+	private boolean isInTheLastTimePoint = true;
+
+	@Parameter
+	private boolean hasLabelMadeOfNumbersOnly = true;
+
+	@Parameter(persist = false)
+	private MamutAppModel appModel;
+
+	@Parameter
+	private LogService logService;
+
+	@Override
+	public void run()
+	{
+		final Logger loggerRoots = logService.subLogger("Searcher...");
+		final Logger loggerSolists = logService.subLogger("Remove Solists");
+
+		final RefList<Spot> solists = new RefArrayList<>(appModel.getModel().getGraph().vertices().getRefPool(),100);
+		final int maxTP = appModel.getMaxTimepoint();
+
+		final SpotsIterator ss = new SpotsIterator(appModel, loggerRoots);
+		ss.visitAllSpots(s -> {
+			if (ss.countAncestors(s) == 0 && ss.countDescendants(s) == 0) {
+				loggerSolists.info("Potential solist: "+s.getLabel()+" at timepoint "+s.getTimepoint());
+				//
+				if (isInTheLastTimePoint && s.getTimepoint() != maxTP) return;
+				if (hasLabelMadeOfNumbersOnly && !StringUtils.isNumeric(s.getLabel())) return;
+				loggerSolists.info("                  ^^^^^ will be removed");
+				solists.add(s);
+			}});
+
+		final ModelGraph g = appModel.getModel().getGraph();
+		for (Spot s : solists) g.remove(s);
+		appModel.getModel().getGraph().notifyGraphChanged();
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/spots/FilterOutSolists.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/spots/FilterOutSolists.java
@@ -45,12 +45,16 @@ import org.scijava.plugin.Plugin;
 public class FilterOutSolists implements Command
 {
 	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false, required = false)
-	final String hintMsg = "Solist has no ancestors and no descendants, plus the conditions below:";
+	final String hintMsg = "A spot-solist has no ancestors and no descendants, plus the optional conditions below:";
 
-	@Parameter
+	@Parameter(label = "And the spot must appear in the last time point:",
+			description = "Lonely spots at the end of the video are much harder" +
+					"to find compared to lonely spots at the beginning.")
 	private boolean isInTheLastTimePoint = true;
 
-	@Parameter
+	@Parameter(label = "And the spot's label consists of numbers only:",
+			description = "A label that is not a number only suggests that" +
+					"user has curated this spot.")
 	private boolean hasLabelMadeOfNumbersOnly = true;
 
 	@Parameter(persist = false)

--- a/src/main/java/org/mastodon/mamut/tomancak/util/SpotsIterator.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/util/SpotsIterator.java
@@ -1,0 +1,276 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2021, 2022, Vladimír Ulman
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.mastodon.mamut.tomancak.util;
+
+import org.mastodon.collection.RefList;
+import org.mastodon.spatial.SpatioTemporalIndex;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.mamut.MamutAppModel;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.Link;
+import org.scijava.log.Logger;
+
+import java.util.function.Consumer;
+
+/** this class is designed to visit and calculate
+ *  user-provided spot handlers in a __single-thread__ fashion
+ *  (because it stores and shares some aux variables) */
+public class SpotsIterator
+{
+	// ========= init =========
+	final Logger ownLogger;
+	final MamutAppModel appModel;
+	final ModelGraph modelGraph;
+	final SelectionModel<Spot, Link> selectionModel;
+
+	//cache...
+	public boolean isSelectionEmpty;
+
+	public SpotsIterator(final MamutAppModel appModel,
+	                     final Logger reporter)
+	{
+		this.ownLogger = reporter;
+		this.appModel = appModel;
+		this.modelGraph = appModel.getModel().getGraph();
+		this.selectionModel = appModel.getSelectionModel();
+	}
+
+
+	// ========= official API =========
+	/** finds roots in the current selection if there is one,
+	 *  or in the entire lineage otherwise, and, in fact,
+	 *  calls visitDownstreamSpots() on the roots */
+	public
+	void visitSpots(final Consumer<Spot> spotHandler)
+	{
+		if (appModel.getSelectionModel().isEmpty())
+			visitAllSpots(spotHandler);
+		else
+			visitSelectedSpots(spotHandler);
+	}
+
+
+	/** finds roots in the current selection and
+	 *  calls visitDownstreamSpots() on them */
+	public
+	void visitSelectedSpots(final Consumer<Spot> spotHandler)
+	{
+		visitRootsFromSelection( rootSpot -> visitDownstreamSpots(rootSpot,spotHandler) );
+	}
+
+
+	/** finds roots in the current whole lineage and
+	 *  calls visitDownstreamSpots() on them */
+	public
+	void visitAllSpots(final Consumer<Spot> spotHandler)
+	{
+		visitRootsFromEntireGraph( rootSpot -> visitDownstreamSpots(rootSpot,spotHandler) );
+	}
+
+
+	// ========= internal (but accessible) API =========
+	public
+	void visitRootsFromSelection(final Consumer<Spot> rootSpotHandler)
+	{
+		isSelectionEmpty = selectionModel.isEmpty();
+		for (Spot spot : selectionModel.getSelectedVertices())
+		{
+			if (countAncestors(spot) == 0)
+			{
+				ownLogger.info("Discovered root "+spot.getLabel());
+				rootSpotHandler.accept(spot);
+			}
+		}
+	}
+
+
+	public
+	void visitRootsFromEntireGraph(final Consumer<Spot> rootSpotHandler)
+	{
+		isSelectionEmpty = true; //pretend there is nothing selected
+
+		final int timeFrom = appModel.getMinTimepoint();
+		final int timeTill = appModel.getMaxTimepoint();
+		final SpatioTemporalIndex<Spot> spots = appModel.getModel().getSpatioTemporalIndex();
+
+		//over all time points and all spots within each time point
+		for (int time = timeFrom; time <= timeTill; ++time)
+		for (final Spot spot : spots.getSpatialIndex(time))
+		{
+			if (countAncestors(spot) == 0)
+			{
+				ownLogger.info("Discovered root "+spot.getLabel());
+				rootSpotHandler.accept(spot);
+			}
+		}
+	}
+
+
+	/** traverses future (higher time point) direct descendants
+	 *  of the given root spot */
+	public
+	void visitDownstreamSpots(final Spot spot,
+	                          final Consumer<Spot> spotHandler)
+	{
+		final Link lRef = modelGraph.edgeRef();
+		final Spot sRef = modelGraph.vertices().createRef();
+
+		spotHandler.accept(spot);
+
+		final int time = spot.getTimepoint();
+		for (int n=0; n < spot.incomingEdges().size(); ++n)
+		{
+			spot.incomingEdges().get(n, lRef).getSource( sRef );
+			if (sRef.getTimepoint() > time && isEligible(sRef))
+			{
+				visitDownstreamSpots(sRef,spotHandler);
+			}
+		}
+
+		for (int n=0; n < spot.outgoingEdges().size(); ++n)
+		{
+			spot.outgoingEdges().get(n, lRef).getTarget( sRef );
+			if (sRef.getTimepoint() > time && isEligible(sRef))
+			{
+				visitDownstreamSpots(sRef,spotHandler);
+			}
+		}
+
+		modelGraph.vertices().releaseRef(sRef);
+		modelGraph.releaseRef(lRef);
+	}
+
+
+	// ========= internal (but accessible) helpers =========
+	public
+	int countAncestors(final Spot spot)
+	{
+		final Link lRef = modelGraph.edgeRef();
+		final Spot sRef = modelGraph.vertices().createRef();
+
+		final int time = spot.getTimepoint();
+		int cnt = 0;
+
+		for (int n=0; n < spot.incomingEdges().size(); ++n)
+		{
+			spot.incomingEdges().get(n, lRef).getSource( sRef );
+			if (sRef.getTimepoint() < time && isEligible(sRef))
+			{
+				++cnt;
+			}
+		}
+
+		for (int n=0; n < spot.outgoingEdges().size(); ++n)
+		{
+			spot.outgoingEdges().get(n, lRef).getTarget( sRef );
+			if (sRef.getTimepoint() < time && isEligible(sRef))
+			{
+				++cnt;
+			}
+		}
+
+		modelGraph.vertices().releaseRef(sRef);
+		modelGraph.releaseRef(lRef);
+
+		return cnt;
+	}
+
+
+	public
+	int countDescendants(final Spot spot)
+	{
+		final Link lRef = modelGraph.edgeRef();
+		final Spot sRef = modelGraph.vertices().createRef();
+
+		final int time = spot.getTimepoint();
+		int cnt = 0;
+
+		for (int n=0; n < spot.incomingEdges().size(); ++n)
+		{
+			spot.incomingEdges().get(n, lRef).getSource( sRef );
+			if (sRef.getTimepoint() > time && isEligible(sRef))
+			{
+				++cnt;
+			}
+		}
+
+		for (int n=0; n < spot.outgoingEdges().size(); ++n)
+		{
+			spot.outgoingEdges().get(n, lRef).getTarget( sRef );
+			if (sRef.getTimepoint() > time && isEligible(sRef))
+			{
+				++cnt;
+			}
+		}
+
+		modelGraph.vertices().releaseRef(sRef);
+		modelGraph.releaseRef(lRef);
+
+		return cnt;
+	}
+
+
+	public
+	void enlistDescendants(final Spot spot,                  //input
+	                       final RefList<Spot> daughterList) //output
+	{
+		final Link lRef = modelGraph.edgeRef();
+		final Spot sRef = modelGraph.vertices().createRef();
+
+		final int time = spot.getTimepoint();
+
+		for (int n=0; n < spot.incomingEdges().size(); ++n)
+		{
+			spot.incomingEdges().get(n, lRef).getSource( sRef );
+			if (sRef.getTimepoint() > time && isEligible(sRef))
+			{
+				daughterList.add(sRef);
+			}
+		}
+
+		for (int n=0; n < spot.outgoingEdges().size(); ++n)
+		{
+			spot.outgoingEdges().get(n, lRef).getTarget( sRef );
+			if (sRef.getTimepoint() > time && isEligible(sRef))
+			{
+				daughterList.add(sRef);
+			}
+		}
+
+		modelGraph.vertices().releaseRef(sRef);
+		modelGraph.releaseRef(lRef);
+	}
+
+
+	public
+	boolean isEligible(final Spot s)
+	{
+		return isSelectionEmpty || selectionModel.isSelected(s);
+	}
+}


### PR DESCRIPTION
Hi @maarzt,

this suggests to add the following plugins:
- Removal of Solists Spots
- Exporter of Spot Counts
- Exporter of Lineage Lengths/Times

It is essentially stealing the code from `mastodon-ext-viewers` where the code landed before... the code of these plugins came to being during the works for Mette.

Anyway, I think it fits here much better, hence this PR.

Technically, this PR works on top of the  #6 . The first commit here is #6 squashed, the remaining two commits are actually contributing the plugins.

Hope you'd like it.