### PR TITLE
Fix path dialog,  issue #165 from Mastodon repo

### DIFF
--- a/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
@@ -116,8 +116,8 @@ public class DatasetPathDialog extends JDialog
 
 		String initialPathValue = tellXmlFilePath( project.getDatasetXmlFile().toPath(), !project.isDatasetXmlPathRelative() );
 		if (projectInContainerFile && project.isDatasetXmlPathRelative() && initialPathValue.startsWith("..")) {
-			//this is hacky, it removes the leading "../" or "..\" from the (for sure!) relative path,
-			//which was here to "get out of" the .mastodon container file and which confuses the Java Path functions
+			//this is hacky, it removes the leading "../" or "..\" from the (for sure!) relative path, which
+			//was here to "get out of" the .mastodon container file, and which also confuses the Java Path functions...
 			initialPathValue = initialPathValue.substring(3);
 		}
 		final JTextField xmlPathTextField = new JTextField( initialPathValue );
@@ -189,13 +189,9 @@ public class DatasetPathDialog extends JDialog
 			final String path = xmlPathTextField.getText();
 			final boolean relative = !storeAbsoluteCheckBox.isSelected();
 
-			File xmlFilePath;
-			if ( relative && projectInContainerFile ) {
-				xmlFilePath = new File( ".." + File.separator + path);
-				System.out.println("Storing BDV xml path with '..' prepended (to get outside the .mastodon container file).");
-			} else {
-				xmlFilePath = new File( path );
-			}
+			//always give the absolute path! -- the underlying spim_data library "relativyfies"
+			//the path on its own (provided the set..Xml..Relative() is set to true)
+			File xmlFilePath = new File( tellXmlFilePath( Paths.get(path), true ) );
 			project.setDatasetXmlFile( xmlFilePath );
 			project.setDatasetXmlPathRelative( relative );
 			System.out.println("Storing BDV xml path as " + xmlFilePath + " (should be relative: " + relative + ")");

--- a/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
@@ -64,7 +64,6 @@ import org.mastodon.ui.util.FileChooser;
 
 public class DatasetPathDialog extends JDialog
 {
-	private final MamutProject project;
 
 	final Path projectRootWoMastodonFile;
 
@@ -90,7 +89,6 @@ public class DatasetPathDialog extends JDialog
 	public DatasetPathDialog( final Frame owner, final MamutProject project )
 	{
 		super( owner, "Edit Dataset Path...", false );
-		this.project = project;
 
 		final boolean projectInContainerFile = project.getProjectRoot().isFile();
 		projectRootWoMastodonFile = projectInContainerFile ?

--- a/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
@@ -67,6 +67,10 @@ public class DatasetPathDialog extends JDialog
 
 	final Path projectRootWoMastodonFile;
 
+	static Path convertFromWinOrLeaveAsIs(final Path relativePath) {
+		return Paths.get( relativePath.toString().replace( "\\", "/" ) );
+	}
+
 	String tellXmlFilePath(final Path xmlFilePath, final boolean tellAsAbsolutePath) {
 		if ( tellAsAbsolutePath ) {
 			if ( xmlFilePath.isAbsolute() )
@@ -114,7 +118,8 @@ public class DatasetPathDialog extends JDialog
 		c.gridx = 0;
 		content.add( new JLabel( "Current BDV dataset path: " ), c );
 
-		String initialPathValue = tellXmlFilePath( project.getDatasetXmlFile().toPath(), !project.isDatasetXmlPathRelative() );
+		String initialPathValue = tellXmlFilePath( convertFromWinOrLeaveAsIs( project.getDatasetXmlFile().toPath() ),
+				!project.isDatasetXmlPathRelative() );
 		if (projectInContainerFile && project.isDatasetXmlPathRelative() && initialPathValue.startsWith("..")) {
 			//this is hacky, it removes the leading "../" or "..\" from the (for sure!) relative path, which
 			//was here to "get out of" the .mastodon container file, and which also confuses the Java Path functions...

--- a/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
@@ -29,6 +29,7 @@
 package org.mastodon.mamut.tomancak;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -47,6 +48,7 @@ import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
+import javax.swing.ButtonModel;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -144,6 +146,20 @@ public class DatasetPathDialog extends JDialog
 
 		c.gridx = 1;
 		content.add( storeAbsoluteCheckBox, c );
+
+		c.gridx = 2;
+		final JButton testButton = new JButton( "Test Path" );
+		content.add( testButton, c );
+		//
+		final Color normalBgColor = xmlPathTextField.getBackground();
+		testButton.addChangeListener(l -> {
+			if ( testButton.getModel().isPressed() ) {
+				final File f = new File( tellXmlFilePath( Paths.get( xmlPathTextField.getText() ), true ) );
+				xmlPathTextField.setBackground( f.isFile() ? Color.GREEN : Color.RED );
+			} else {
+				xmlPathTextField.setBackground( normalBgColor );
+			}
+		});
 
 		final JPanel infoLine = new JPanel();
 		infoLine.setLayout( new BoxLayout( infoLine, BoxLayout.LINE_AXIS ) );

--- a/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
@@ -140,6 +140,11 @@ public class DatasetPathDialog extends JDialog
 		c.gridx = 1;
 		content.add( storeAbsoluteCheckBox, c );
 
+		final JPanel infoLine = new JPanel();
+		infoLine.setLayout( new BoxLayout( infoLine, BoxLayout.LINE_AXIS ) );
+		infoLine.add( Box.createHorizontalGlue() );
+		infoLine.add( new JLabel( "Save the project eventually to make the changes permanent." ) );
+
 		final JPanel buttons = new JPanel();
 		final JButton cancel = new JButton("Cancel");
 		final JButton ok = new JButton("OK");
@@ -148,7 +153,8 @@ public class DatasetPathDialog extends JDialog
 		buttons.add( cancel );
 		buttons.add( ok );
 
-		getContentPane().add( content, BorderLayout.CENTER );
+		getContentPane().add( content, BorderLayout.NORTH );
+		getContentPane().add( infoLine, BorderLayout.CENTER );
 		getContentPane().add( buttons, BorderLayout.SOUTH );
 
 		class Browse implements ActionListener

--- a/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/DatasetPathDialog.java
@@ -88,7 +88,7 @@ public class DatasetPathDialog extends JDialog
 
 	public DatasetPathDialog( final Frame owner, final MamutProject project )
 	{
-		super( owner, "Edit Dataset Path...", false );
+		super( owner, "Edit Dataset Path...", true );
 
 		final boolean projectInContainerFile = project.getProjectRoot().isFile();
 		projectRootWoMastodonFile = projectInContainerFile ?


### PR DESCRIPTION
solves https://github.com/mastodon-sc/mastodon/issues/165 by

- making the dialog more verbose, showing a bit more information
- making the dialog more interactive, user can work in iterations
- windows paths are auto-changed to unix one
- unix paths Java manages well on windows, so no extra care had to be taken
- added Test Path button

Tested on linux and windows. My feeling is that moving `.mastodon` files with their image data around (within one drive, between OSes and people) is now really easy... and when a mismatch occurs (`.mastodon` will not be able to open its image data), this dialog *Fix Image Path* (now in File menu) comes to rescue.
