### PR TITLE
More Lineage Registration Functionalities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
 			<version>${mastodon.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.mastodon</groupId>
+			<artifactId>mastodon-blender-view</artifactId>
+			<version>0.1.3-SNAPSHOT</version>
+		</dependency>
+		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>spim_data</artifactId>
 		</dependency>
@@ -51,6 +56,11 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jfree</groupId>
+			<artifactId>jfreechart</artifactId>
 			<scope>test</scope>
 		</dependency>
 
@@ -109,6 +119,19 @@
 	</developers>
 
 	<contributors><contributor><name>none</name></contributor></contributors>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<argLine>-Xmx2G</argLine>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<repositories>
 		<repository>

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationAlgorithm.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationAlgorithm.java
@@ -1,9 +1,12 @@
 package org.mastodon.mamut.tomancak.lineage_registration;
 
 import net.imglib2.realtransform.AffineTransform3D;
+
+import org.mastodon.adapter.RefBimap;
 import org.mastodon.collection.RefList;
 import org.mastodon.collection.RefRefMap;
 import org.mastodon.collection.ref.RefArrayList;
+import org.mastodon.collection.ref.RefRefHashMap;
 import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.ModelGraph;
 import org.mastodon.mamut.model.Spot;
@@ -22,8 +25,8 @@ public class LineageRegistrationAlgorithm
 	private final ModelGraph graphA;
 	
 	private final ModelGraph graphB;
-	
-	private final RefList< Spot > toBeFlipped;
+
+	private final RefRefMap< Spot, Spot > map;
 
 	public static void run( Model embryoA, Model embryoB )
 	{
@@ -31,10 +34,11 @@ public class LineageRegistrationAlgorithm
 		ModelGraph graphB = embryoB.getGraph();
 		RefRefMap< Spot, Spot > roots = RootsPairing.pairRoots( graphA, graphB );
 		AffineTransform3D transformAB = EstimateTransformation.estimateScaleRotationAndTranslation( roots );
-		RefList< Spot > toBeFlipped = new LineageRegistrationAlgorithm(
+		LineageRegistrationAlgorithm algorithm = new LineageRegistrationAlgorithm(
 				graphA, graphB,
-				roots, transformAB ).getToBeFlipped();
-		FlipDescendants.flipDescendants( embryoB, toBeFlipped );
+				roots, transformAB );
+		RefList< Spot > flip = algorithm.getToBeFlipped();
+		FlipDescendants.flipDescendants( embryoB, flip );
 	}
 
 	public LineageRegistrationAlgorithm( ModelGraph graphA, ModelGraph graphB, RefRefMap< Spot, Spot > roots,
@@ -42,7 +46,7 @@ public class LineageRegistrationAlgorithm
 		this.transformAB = noOffsetTransform( transformAB );
 		this.graphA = graphA;
 		this.graphB = graphB;
-		this.toBeFlipped = new RefArrayList<>( graphB.vertices().getRefPool() );
+		this.map = new RefRefHashMap<>( graphA.vertices().getRefPool(), graphB.vertices().getRefPool() );
 		for( Spot rootA : roots.keySet() ) {
 			Spot rootB = roots.get( rootA );
 			matchTree( rootA, rootB );
@@ -51,19 +55,19 @@ public class LineageRegistrationAlgorithm
 
 	private void matchTree(Spot rootA, Spot rootB)
 	{
+		map.put( rootA, rootB );
 		Spot dividingA = LineageTreeUtils.getBranchEnd( graphA, rootA );
 		Spot dividingB = LineageTreeUtils.getBranchEnd( graphB, rootB );
 		try
 		{
-			if(dividingA.outgoingEdges().size() != 2 ||
-			  dividingB.outgoingEdges().size() != 2)
+			boolean bothDivide = dividingA.outgoingEdges().size() == 2 &&
+					dividingB.outgoingEdges().size() == 2;
+			if( ! bothDivide )
 				return;
 			double[] directionA = SortTreeUtils.directionOfCellDevision( graphA, dividingA );
 			double[] directionB = SortTreeUtils.directionOfCellDevision( graphB, dividingB );
 			transformAB.apply( directionA, directionA );
 			boolean flip = SortTreeUtils.scalarProduct( directionA, directionB ) < 0;
-			if(flip)
-				toBeFlipped.add( dividingB );
 			matchChildTree( dividingA, dividingB, 0, flip ? 1 : 0 );
 			matchChildTree( dividingA, dividingB, 1, flip ? 0 : 1 );
 		} finally
@@ -90,7 +94,54 @@ public class LineageRegistrationAlgorithm
 
 	public RefList< Spot > getToBeFlipped()
 	{
-		return toBeFlipped;
+		Spot ref = graphB.vertexRef();
+		try
+		{
+			RefArrayList< Spot > list = new RefArrayList<>( graphB.vertices().getRefPool() );
+			for ( Spot spotA : map.keySet() )
+			{
+				Spot spotB = map.get( spotA, ref );
+				if( doFlip( spotA, spotB ) )
+					list.add( spotB );
+			}
+			return list;
+		}
+		finally
+		{
+			graphB.releaseRef( ref );
+		}
+	}
+
+	private boolean doFlip( Spot spotA, Spot spotB )
+	{
+		Spot dividedA = LineageTreeUtils.getBranchEnd( graphA, spotA );
+		Spot dividedB = LineageTreeUtils.getBranchEnd( graphB, spotB );
+		Spot refA = graphA.vertexRef();
+		Spot refB = graphB.vertexRef();
+		Spot refB2 = graphB.vertexRef();
+		try
+		{
+			boolean bothDivide = dividedA.outgoingEdges().size() == 2 &&
+					dividedB.outgoingEdges().size() == 2;
+			if ( !bothDivide )
+				return false;
+			Spot firstChildA = dividedA.outgoingEdges().get( 0 ).getTarget( refA );
+			Spot secondChildB = dividedB.outgoingEdges().get( 1 ).getTarget( refB );
+			return map.get( firstChildA, refB2 ).equals( secondChildB );
+		}
+		finally
+		{
+			graphA.releaseRef( dividedA );
+			graphA.releaseRef( refA );
+			graphB.releaseRef( dividedB );
+			graphB.releaseRef( refB );
+			graphB.releaseRef( refB2 );
+		}
+	}
+
+	public RefRefMap< Spot, Spot > getMapping()
+	{
+		return map;
 	}
 	
 	private static AffineTransform3D noOffsetTransform( AffineTransform3D transformAB )

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageTreeUtils.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageTreeUtils.java
@@ -1,7 +1,10 @@
 package org.mastodon.mamut.tomancak.lineage_registration;
 
+import org.mastodon.collection.RefList;
 import org.mastodon.collection.RefSet;
+import org.mastodon.collection.ref.RefArrayList;
 import org.mastodon.collection.ref.RefSetImp;
+import org.mastodon.mamut.model.Link;
 import org.mastodon.mamut.model.ModelGraph;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.pool.PoolCollectionWrapper;
@@ -46,6 +49,27 @@ public class LineageTreeUtils
 		}
 		finally {
 			graph.releaseRef( branchEnd );		
+		}
+	}
+
+	public static RefList<Spot> getBranchStarts( ModelGraph graph ) {
+		Spot ref = graph.vertexRef();
+		try
+		{
+			RefArrayList< Spot > l = new RefArrayList<>( graph.vertices().getRefPool() );
+			for ( Spot spot : graph.vertices() )
+			{
+				if ( spot.incomingEdges().size() != 1 )
+					l.add( spot );
+				if ( spot.outgoingEdges().size() > 1 )
+					for ( Link link : spot.outgoingEdges() )
+						l.add( link.getTarget( ref ) );
+			}
+			return l;
+		}
+		finally
+		{
+			graph.releaseRef( ref );
 		}
 	}
 }

--- a/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageColoring.java
+++ b/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageColoring.java
@@ -39,7 +39,7 @@ public class LineageColoring
 
 	private static void tagLineages( Map<String, Integer> colorMap, RefCollection< Spot > roots, Model model )
 	{
-		TagSetStructure.TagSet tagSet = createTagSet( model, colorMap );
+		TagSetStructure.TagSet tagSet = createTagSet( model, "lineages", colorMap );
 		Map< String, TagSetStructure.Tag > tags = tagSet.getTags().stream()
 				.collect( Collectors.toMap( TagSetStructure.Tag::label, tag -> tag ) );
 		for( Spot root : roots ) {
@@ -84,11 +84,11 @@ public class LineageColoring
 		search.start( root );
 	}
 
-	private static TagSetStructure.TagSet createTagSet( Model model, Map<String, Integer> tagsAndColors )
+	public static TagSetStructure.TagSet createTagSet( Model model, String title, Map<String, Integer> tagsAndColors )
 	{
 		TagSetModel<Spot, Link> tagSetModel = model.getTagSetModel();
 		TagSetStructure tss = copy( tagSetModel.getTagSetStructure() );
-		TagSetStructure.TagSet tagSet = tss.createTagSet("lineages");
+		TagSetStructure.TagSet tagSet = tss.createTagSet(title);
 		tagsAndColors.forEach( tagSet::createTag );
 		tagSetModel.setTagSetStructure( tss );
 		return tagSet;

--- a/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationDemo.java
+++ b/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationDemo.java
@@ -75,10 +75,19 @@ public class LineageRegistrationDemo
 			spotB.localize( positionB );
 			transformAB.applyInverse( positionB, positionB );
 			double distance = LinAlgHelpers.distance( positionA, positionB );
-			int gray = 255 - (int) (Math.min( 1.0, distance / sizeA * 10 ) * 255);
-			int color = 0xff000000 + gray + (gray << 8) + (gray << 16);
-			return color;
+			return gray( 1 - distance / sizeA * 5 );
 		} );
+	}
+
+	private int gray( double b )
+	{
+		if ( b > 1 )
+			b = 1;
+		if ( b < 0 )
+			b = 0;
+		int gray = (int) (b * 255);
+		int color = 0xff000000 + gray + (gray << 8) + (gray << 16);
+		return color;
 	}
 
 	private double sizeEstimate( ModelGraph graphB )

--- a/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationDemo.java
+++ b/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationDemo.java
@@ -1,22 +1,36 @@
 package org.mastodon.mamut.tomancak.lineage_registration;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import mpicbg.spim.data.SpimDataException;
+import net.imglib2.FinalRealInterval;
+import net.imglib2.RealInterval;
+import net.imglib2.realtransform.AffineTransform3D;
+import org.mastodon.blender.BlenderController;
+import org.mastodon.collection.RefCollection;
+import org.mastodon.collection.RefRefMap;
 import org.mastodon.mamut.MainWindow;
 import org.mastodon.mamut.MamutAppModel;
 import org.mastodon.mamut.WindowManager;
+import org.mastodon.mamut.model.Link;
 import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.project.MamutProject;
 import org.mastodon.mamut.project.MamutProjectIO;
+import org.mastodon.model.tag.ObjTags;
+import org.mastodon.model.tag.TagSetStructure;
 import org.scijava.Context;
 
 public class LineageRegistrationDemo
 {
 
-	public Model embryoA;
+	private final Context context;
 
-	public Model embryoB;
+	public final MamutAppModel embryoA;
+
+	public final MamutAppModel embryoB;
 
 	public static void main(String... args) {
 		new LineageRegistrationDemo().run();
@@ -24,15 +38,104 @@ public class LineageRegistrationDemo
 
 	private LineageRegistrationDemo()
 	{
-		Context context = new Context();
-		embryoA = openAppModel( context, "/home/arzt/Datasets/Mette/E1.mastodon" ).getModel();
-		embryoB = openAppModel( context, "/home/arzt/Datasets/Mette/E2.mastodon" ).getModel();
+		this.context = new Context();
+		this.embryoA = openAppModel( context, "/home/arzt/Datasets/Mette/E1.mastodon" );
+		this.embryoB = openAppModel( context, "/home/arzt/Datasets/Mette/E2.mastodon" );
 	}
 
 	public void run()
 	{
-		LineageColoring.tagLineages( embryoA, embryoB );
-		LineageRegistrationAlgorithm.run( embryoA, embryoB );
+		LineageColoring.tagLineages( embryoA.getModel(), embryoB.getModel() );
+		LineageRegistrationAlgorithm.run( embryoA.getModel(), embryoB.getModel() );
+		addNotMappedTag();
+		colorAccordingToPosition();
+	}
+
+	private void addNotMappedTag()
+	{
+		RefRefMap< Spot, Spot > mapping = getMapping();
+		TagSetStructure.TagSet tagSet = LineageColoring.createTagSet( embryoA.getModel(), "registration", Collections.singletonMap( "not mapped", 0xffff2222 ) );
+		TagSetStructure.Tag tag = tagSet.getTags().get( 0 );
+		ModelGraph graphA = embryoA.getModel().getGraph();
+		for( Spot spotA : LineageTreeUtils.getBranchStarts( graphA ) ) {
+			Spot spotB = mapping.get( spotA );
+			if( spotB == null )
+				tagBranch( tag, embryoA.getModel(), spotA );
+		}
+	}
+
+	private void tagBranch( TagSetStructure.Tag tag, Model model, Spot spotA )
+	{
+		ModelGraph graphA = model.getGraph();
+		Spot spot = graphA.vertexRef();
+		try
+		{
+			ObjTags< Spot > vertexTags = model.getTagSetModel().getVertexTags();
+			ObjTags< Link > edgeTags = model.getTagSetModel().getEdgeTags();
+			spot.refTo( spotA );
+			vertexTags.set( spot, tag );
+			while ( spot.outgoingEdges().size() == 1 )
+			{
+				Link link = spot.outgoingEdges().get( 0 );
+				edgeTags.set( link, tag );
+				spot = link.getTarget( spot );
+				vertexTags.set( spot, tag );
+			}
+		}
+		finally
+		{
+			graphA.releaseRef( spot );
+		}
+	}
+
+	private void colorAccordingToPosition()
+	{
+		RefRefMap< Spot, Spot > mapping = getMapping();
+		BlenderController blender = new BlenderController( context, embryoA );
+		ModelGraph graphB = embryoB.getModel().getGraph();
+		RealInterval boundingBox = boundingBox(graphB.vertices());
+		double[] coords = new double[3];
+		blender.sendColors( spotA -> {
+			Spot ref = graphB.vertexRef();
+			Spot spotB = mapping.get( spotA, ref );
+			if( spotB == null )
+				return 0xff000000;
+			spotB.localize( coords );
+			return 0xff000000 | channel( boundingBox, coords, 0 ) | channel( boundingBox, coords, 1 ) << 8 | channel( boundingBox, coords, 2 ) << 16;
+		} );
+	}
+
+	private int channel( RealInterval boundingBox, double[] coords, int i )
+	{
+		double v = ( coords[ i ] - boundingBox.realMin( i ) ) / ( boundingBox.realMax( i ) - boundingBox.realMin( i ) );
+		return ( int ) ( 255 * v );
+	}
+
+	private RealInterval boundingBox( RefCollection< Spot> vertices )
+	{
+		double[] coords = { 0, 0, 0 };
+		double[] min = { Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY };
+		double[] max = { Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY };
+		for( Spot spot : vertices ) {
+			spot.localize( coords );
+			for ( int i = 0; i < 3; i++ )
+			{
+				min[i] = Math.min( min[i], coords[i] );
+				max[i] = Math.max( max[i], coords[i] );
+			}
+		}
+		return new FinalRealInterval( min, max );
+	}
+
+	private RefRefMap< Spot, Spot > getMapping()
+	{
+		ModelGraph graphA = embryoA.getModel().getGraph();
+		ModelGraph graphB = embryoB.getModel().getGraph();
+		RefRefMap< Spot, Spot > roots = RootsPairing.pairRoots( graphA, graphB );
+		AffineTransform3D transformAB = EstimateTransformation.estimateScaleRotationAndTranslation( roots );
+		return new LineageRegistrationAlgorithm(
+				graphA, graphB,
+				roots, transformAB ).getMapping();
 	}
 
 	private static MamutAppModel openAppModel( Context context, String projectPath )


### PR DESCRIPTION
* Visualize spots of embryoA, color them with respect to the position of the matched branch spot in embryB.
  This visualization is hard to process for my eyes. It's hard to see any problems.
* Create a tag for unmatched spots. This helped to find parts of the lineage that where not stereotypic.
* Color the spots of embryoA in blender, depending of how far away they are from there paired branch spot.
  It's easy to process by my eyes but there are only two outliers and I can not spot it is wrongly matched or not.

Potential plugins to develope based on this:
1. Synchronize selection between the two embryos.
2. Copy a tagset from one embryo to the other
3. Automatic sorting of the TrackScheme
4. Tag those spots which should be flipped