### PR TITLE
Lineage Registration: allow to register embryos that start on different stages

### DIFF
--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageColoring.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageColoring.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.mastodon.collection.RefCollection;
 import org.mastodon.collection.RefRefMap;
+import org.mastodon.graph.algorithm.traversal.DepthFirstIterator;
 import org.mastodon.graph.algorithm.traversal.DepthFirstSearch;
 import org.mastodon.graph.algorithm.traversal.GraphSearch;
 import org.mastodon.graph.algorithm.traversal.SearchListener;
@@ -50,38 +51,14 @@ public class LineageColoring
 	{
 		ObjTagMap< Spot, TagSetStructure.Tag > spotTags = model.getTagSetModel().getVertexTags().tags( tagSet );
 		ObjTagMap< Link, TagSetStructure.Tag > edgeTags = model.getTagSetModel().getEdgeTags().tags( tagSet );
-
-		SearchListener< Spot, Link, DepthFirstSearch< Spot, Link > > searchListener =
-				new SearchListener< Spot, Link, DepthFirstSearch< Spot, Link > >()
-				{
-					@Override
-					public void processVertexLate( Spot spot, DepthFirstSearch< Spot, Link > search )
-					{
-						// do nothing
-					}
-
-					@Override
-					public void processVertexEarly( Spot spot, DepthFirstSearch< Spot, Link > spotLinkDepthFirstSearch )
-					{
-						spotTags.set( spot, tag );
-					}
-
-					@Override
-					public void processEdge( Link link, Spot spot, Spot v1, DepthFirstSearch< Spot, Link > spotLinkDepthFirstSearch )
-					{
-						edgeTags.set( link, tag );
-					}
-
-					@Override
-					public void crossComponent( Spot spot, Spot v1, DepthFirstSearch< Spot, Link > spotLinkDepthFirstSearch )
-					{
-						// do nothing
-					}
-				};
-
-		DepthFirstSearch< Spot, Link > search = new DepthFirstSearch<>( model.getGraph(), GraphSearch.SearchDirection.DIRECTED );
-		search.setTraversalListener( searchListener );
-		search.start( root );
+		DepthFirstIterator< Spot, Link > iterator = new DepthFirstIterator<>( root, model.getGraph() );
+		while ( iterator.hasNext() )
+		{
+			Spot spot = iterator.next();
+			spotTags.set( spot, tag );
+			for ( Link edge : spot.outgoingEdges() )
+				edgeTags.set( edge, tag );
+		}
 	}
 
 	/**

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageColoring.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageColoring.java
@@ -27,9 +27,11 @@ public class LineageColoring
 	 * The tags of matching roots node gets the same colors assigned.
 	 * Finally, the tag is applied to all the descendants of a root node.
 	 */
-	public static void tagLineages( Model embryoA, Model embryoB )
+	public static void tagLineages( Model embryoA, int firstTimepointA, Model embryoB, int firstTimepointB )
 	{
-		RefRefMap< Spot, Spot > roots = RootsPairing.pairDividingRoots( embryoA.getGraph(), embryoB.getGraph() );
+		RefRefMap< Spot, Spot > roots = RootsPairing.pairDividingRoots(
+				embryoA.getGraph(), firstTimepointA,
+				embryoB.getGraph(), firstTimepointB );
 		List< String > labels = roots.keySet().stream().map( Spot::getLabel ).sorted().collect( Collectors.toList() );
 		Map< String, Integer > colorMap = createColorMap( labels );
 		tagLineages( colorMap, roots.keySet(), embryoA );

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationAlgorithm.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationAlgorithm.java
@@ -28,19 +28,20 @@ public class LineageRegistrationAlgorithm
 	 */
 	private final RefRefMap< Spot, Spot > mapAB;
 
+	public static RegisteredGraphs run( ModelGraph graphA, int firstTimepointA, ModelGraph graphB, int firstTimepointB )
+	{
+		RefRefMap< Spot, Spot > roots = RootsPairing.pairDividingRoots( graphA, firstTimepointA, graphB, firstTimepointB );
+		AffineTransform3D transformAB = EstimateTransformation.estimateScaleRotationAndTranslation( roots );
+		return run( graphA, graphB, roots, transformAB );
+	}
+
 	public static RegisteredGraphs run( ModelGraph graphA, ModelGraph graphB,
 			RefRefMap< Spot, Spot > roots, AffineTransform3D transformAB )
 	{
-		RefRefMap< Spot, Spot > mapping = calculateMapping( graphA, graphB, roots, transformAB );
-		return new RegisteredGraphs( graphA, graphB, transformAB, mapping );
-	}
-
-	private static RefRefMap< Spot, Spot > calculateMapping( ModelGraph graphA, ModelGraph graphB,
-			RefRefMap< Spot, Spot > roots, AffineTransform3D transformAB )
-	{
-		return new LineageRegistrationAlgorithm(
+		RefRefMap< Spot, Spot > mapping = new LineageRegistrationAlgorithm(
 				graphA, graphB,
 				roots, transformAB ).getMapping();
+		return new RegisteredGraphs( graphA, graphB, transformAB, mapping );
 	}
 
 	private LineageRegistrationAlgorithm( ModelGraph graphA, ModelGraph graphB, RefRefMap< Spot, Spot > roots,
@@ -63,14 +64,6 @@ public class LineageRegistrationAlgorithm
 		{
 			graphB.releaseRef( refB );
 		}
-	}
-
-	public static RegisteredGraphs run( ModelGraph graphA, ModelGraph graphB )
-	{
-		RefRefMap< Spot, Spot > roots = RootsPairing.pairDividingRoots( graphA, graphB );
-		AffineTransform3D transformAB = EstimateTransformation.estimateScaleRotationAndTranslation( roots );
-		RegisteredGraphs result = run( graphA, graphB, roots, transformAB );
-		return result;
 	}
 
 	private void matchTree( Spot rootA, Spot rootB )

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationFrame.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationFrame.java
@@ -140,9 +140,9 @@ public class LineageRegistrationFrame extends JFrame
 
 	private void updateEnableButtons()
 	{
-		WindowManager projectA = getProjectA();
-		WindowManager projectB = getProjectB();
-		final boolean enabled = projectA != null && projectB != null && projectA != projectB;
+		SelectedProject projectA = getProjectA();
+		SelectedProject projectB = getProjectB();
+		final boolean enabled = projectA != null && projectB != null && projectA.getWindowManager() != projectB.getWindowManager();
 		for ( JComponent b : buttons )
 			b.setEnabled( enabled );
 	}
@@ -228,8 +228,8 @@ public class LineageRegistrationFrame extends JFrame
 
 	public void setMastodonInstances( List< WindowManager > instances )
 	{
-		WindowManager a = getProjectA();
-		WindowManager b = getProjectB();
+		WindowManager a = getProjectA().getWindowManager();
+		WindowManager b = getProjectB().getWindowManager();
 		comboBoxA.removeAllItems();
 		comboBoxB.removeAllItems();
 		for ( WindowManager windowManager : instances )
@@ -255,22 +255,23 @@ public class LineageRegistrationFrame extends JFrame
 			comboBox.setSelectedIndex( defaultIndex );
 	}
 
-	public WindowManager getProjectA()
+	public SelectedProject getProjectA()
 	{
 		return getSelected( comboBoxA );
 	}
 
-	public WindowManager getProjectB()
+	public SelectedProject getProjectB()
 	{
 		return getSelected( comboBoxB );
 	}
 
-	private WindowManager getSelected( JComboBox< MastodonInstance > comboBoxA )
+	private SelectedProject getSelected( JComboBox< MastodonInstance > comboBoxA )
 	{
 		Object selectedItem = comboBoxA.getSelectedItem();
 		if ( selectedItem == null )
 			return null;
-		return ( ( MastodonInstance ) selectedItem ).windowManager;
+		WindowManager windowManager = ( ( MastodonInstance ) selectedItem ).windowManager;
+		return new SelectedProject( windowManager, getProjectName( windowManager ) );
 	}
 
 	private static class MastodonInstance

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationUtils.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationUtils.java
@@ -35,9 +35,8 @@ public class LineageRegistrationUtils
 	 * The sorting is based on the result of the
 	 * {@link LineageRegistrationAlgorithm}.
 	 */
-	public static void sortSecondTrackSchemeToMatch( Model modelA, Model modelB )
+	public static void sortSecondTrackSchemeToMatch( Model modelA, Model modelB, RegisteredGraphs result )
 	{
-		RegisteredGraphs result = LineageRegistrationAlgorithm.run( modelA.getGraph(), modelB.getGraph() );
 		RefList< Spot > spotsToFlipB = getSpotsToFlipB( result );
 		FlipDescendants.flipDescendants( modelB, spotsToFlipB );
 	}
@@ -48,10 +47,9 @@ public class LineageRegistrationUtils
 	 * between the branches in modelA and modelB. The tags are copied from
 	 * the branches  in modelA to the corresponding branches in modelB.
 	 */
-	public static TagSetStructure.TagSet copyTagSetToSecond( Model modelA, Model modelB,
+	public static TagSetStructure.TagSet copyTagSetToSecond( Model modelA, Model modelB, RegisteredGraphs result,
 			TagSetStructure.TagSet tagSetModelA, String newTagSetName )
 	{
-		RegisteredGraphs result = LineageRegistrationAlgorithm.run( modelA.getGraph(), modelB.getGraph() );
 		List< Pair< String, Integer > > tags = tagSetModelA.getTags().stream()
 				.map( t -> Pair.of( t.label(), t.color() ) )
 				.collect( Collectors.toList() );
@@ -138,9 +136,8 @@ public class LineageRegistrationUtils
 	 * Creates a new tag set in both models. It runs the {@link LineageRegistrationAlgorithm}
 	 * and tags unmatched and flipped cells / branches.
 	 */
-	public static void tagCells( Model modelA, Model modelB, boolean modifyA, boolean modifyB )
+	public static void tagCells( Model modelA, Model modelB, RegisteredGraphs result, boolean modifyA, boolean modifyB )
 	{
-		RegisteredGraphs result = LineageRegistrationAlgorithm.run( modelA.getGraph(), modelB.getGraph() );
 		if ( modifyA )
 			tagSpotsA( modelA, result );
 		if ( modifyB )

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/RefCollectionUtils.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/RefCollectionUtils.java
@@ -1,0 +1,39 @@
+package org.mastodon.mamut.tomancak.lineage_registration;
+
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+import org.mastodon.RefPool;
+import org.mastodon.collection.RefCollection;
+import org.mastodon.collection.RefCollections;
+import org.mastodon.collection.RefRefMap;
+import org.mastodon.collection.RefSet;
+
+public class RefCollectionUtils
+{
+
+	public static < T > RefSet< T > filterSet( RefCollection< T > values, Predicate< T > predicate )
+	{
+		RefSet< T > filtered = RefCollections.createRefSet( values );
+		for ( T t : values )
+			if ( predicate.test( t ) )
+				filtered.add( t );
+		return filtered;
+	}
+
+	public static < T > RefSet< T > applySet( RefCollection< T > values, UnaryOperator< T > function )
+	{
+		RefSet< T > filtered = RefCollections.createRefSet( values );
+		for ( T t : values )
+			filtered.add( function.apply( t ) );
+		return filtered;
+	}
+
+	public static < T > RefPool< T > getRefPool( RefCollection< T > collection )
+	{
+		RefPool< T > pool = RefCollections.tryGetRefPool( collection );
+		if ( pool == null )
+			throw new IllegalArgumentException( "Could not get RefPool from the given RefSet." );
+		return pool;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/RegisteredGraphs.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/RegisteredGraphs.java
@@ -13,7 +13,7 @@ import org.mastodon.mamut.model.Spot;
  * This datastructure holds two {@link ModelGraph}s and a mapping between them.
  * </p>
  * <p>
- * This is also the return type of {@link LineageRegistrationAlgorithm#run(ModelGraph, ModelGraph)}.
+ * This is also the return type of {@link LineageRegistrationAlgorithm#run}.
  * </p>
  */
 public class RegisteredGraphs

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/RootsPairing.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/RootsPairing.java
@@ -1,9 +1,12 @@
 package org.mastodon.mamut.tomancak.lineage_registration;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
+import org.mastodon.RefPool;
 import org.mastodon.collection.ObjectRefMap;
+import org.mastodon.collection.RefCollections;
 import org.mastodon.collection.RefRefMap;
 import org.mastodon.collection.RefSet;
 import org.mastodon.collection.ref.ObjectRefHashMap;
@@ -32,28 +35,57 @@ public class RootsPairing
 	 * @return a map, that maps root nodes in graph A to equally named
 	 * root nodes of graph B.
 	 */
-	static RefRefMap< Spot, Spot > pairDividingRoots( ModelGraph graphA, ModelGraph graphB )
+	static RefRefMap< Spot, Spot > pairDividingRoots( ModelGraph graphA, int timepointA, ModelGraph graphB, int timepointB )
 	{
-		ObjectRefMap< String, Spot > rootsA = dividingRootsMap( graphA );
-		ObjectRefMap< String, Spot > rootsB = dividingRootsMap( graphB );
-		Set< String > intersection = intersection( rootsA.keySet(), rootsB.keySet() );
-		RefRefMap< Spot, Spot > roots = new RefRefHashMap<>( graphA.vertices().getRefPool(), graphB.vertices().getRefPool() );
-		for ( String label : intersection )
-			roots.put( rootsA.get( label ), rootsB.get( label ) );
+		RefSet< Spot > rootsA = getBranchStarts( filterDividingSpots( LineageTreeUtils.getRoots( graphA, timepointA ) ) );
+		RefSet< Spot > rootsB = getBranchStarts( filterDividingSpots( LineageTreeUtils.getRoots( graphB, timepointB ) ) );
+		return pairSpotsBasedOnLabel( rootsA, rootsB );
+	}
+
+	private static RefRefMap< Spot, Spot > pairSpotsBasedOnLabel( RefSet< Spot > spotsA, RefSet< Spot > spotsB )
+	{
+		ObjectRefMap< String, Spot > labelToSpotsA = createLabelToSpotMap( spotsA );
+		ObjectRefMap< String, Spot > labelToSpotsB = createLabelToSpotMap( spotsB );
+		RefRefMap< Spot, Spot > roots =
+				new RefRefHashMap<>( RefCollectionUtils.getRefPool( spotsA ), RefCollectionUtils.getRefPool( spotsB ) );
+		for ( String label : intersection( labelToSpotsA.keySet(), labelToSpotsB.keySet() ) )
+			roots.put( labelToSpotsA.get( label ), labelToSpotsB.get( label ) );
 		return roots;
 	}
 
-	/**
-	 * @return a map that maps "root labels" to "root spots" for the given graph.
-	 * The map only contains those roots that actually divide.
-	 */
-	private static ObjectRefMap< String, Spot > dividingRootsMap( ModelGraph graphA )
+	private static RefSet< Spot > filterDividingSpots( RefSet< Spot > spots )
 	{
-		RefSet< Spot > roots = LineageTreeUtils.getRoots( graphA );
-		ObjectRefMap< String, Spot > map = new ObjectRefHashMap<>( graphA.vertices().getRefPool() );
-		for ( Spot spot : roots )
-			if ( LineageTreeUtils.doesBranchDivide( graphA, spot ) )
-				map.put( spot.getLabel(), spot );
+		Spot ref = spots.createRef();
+		try
+		{
+			return RefCollectionUtils.filterSet( spots, spot -> LineageTreeUtils.doesBranchDivide( spot, ref ) );
+		}
+		finally
+		{
+			spots.releaseRef( ref );
+		}
+	}
+
+	private static RefSet< Spot > getBranchStarts( RefSet< Spot > spots )
+	{
+		Spot ref = spots.createRef();
+		try
+		{
+			return RefCollectionUtils.applySet( spots, spot -> BranchGraphUtils.getBranchStart( spot, ref ) );
+		}
+		finally
+		{
+			spots.releaseRef( ref );
+		}
+
+	}
+
+	private static ObjectRefMap< String, Spot > createLabelToSpotMap( RefSet< Spot > dividingRoots )
+	{
+		RefPool< Spot > spotRefPool = Objects.requireNonNull( RefCollections.tryGetRefPool( dividingRoots ) );
+		ObjectRefMap< String, Spot > map = new ObjectRefHashMap<>( spotRefPool );
+		for ( Spot spot : dividingRoots )
+			map.put( spot.getLabel(), spot );
 		return map;
 	}
 

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/SelectedProject.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/SelectedProject.java
@@ -1,0 +1,49 @@
+package org.mastodon.mamut.tomancak.lineage_registration;
+
+import org.mastodon.mamut.MamutAppModel;
+import org.mastodon.mamut.WindowManager;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+
+/**
+ * Used in {@link LineageRegistrationFrame} and {@link LineageRegistrationControlService}
+ * to exchange information about the selected projects and related sittings.
+ */
+public class SelectedProject
+{
+
+	private final String name;
+
+	private final WindowManager windowManager;
+
+	public SelectedProject( WindowManager windowManager, String name )
+	{
+		this.windowManager = windowManager;
+		this.name = name;
+	}
+
+	public String getName()
+	{
+		return name;
+	}
+
+	public WindowManager getWindowManager()
+	{
+		return windowManager;
+	}
+
+	public MamutAppModel getAppModel()
+	{
+		return windowManager.getAppModel();
+	}
+
+	public Model getModel()
+	{
+		return getAppModel().getModel();
+	}
+
+	public ModelGraph getGraph()
+	{
+		return getModel().getGraph();
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/SelectedProject.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/lineage_registration/SelectedProject.java
@@ -16,10 +16,13 @@ public class SelectedProject
 
 	private final WindowManager windowManager;
 
-	public SelectedProject( WindowManager windowManager, String name )
+	private final int firstTimepoint;
+
+	public SelectedProject( WindowManager windowManager, String name, int firstTimepoint )
 	{
 		this.windowManager = windowManager;
 		this.name = name;
+		this.firstTimepoint = firstTimepoint;
 	}
 
 	public String getName()
@@ -30,6 +33,11 @@ public class SelectedProject
 	public WindowManager getWindowManager()
 	{
 		return windowManager;
+	}
+
+	public int getFirstTimepoint()
+	{
+		return firstTimepoint;
 	}
 
 	public MamutAppModel getAppModel()

--- a/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/EmbryoA.java
+++ b/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/EmbryoA.java
@@ -14,47 +14,53 @@ class EmbryoA
 
 	final ModelGraph graph = model.getGraph();
 
-	final Spot a = addSpot( graph, null, "A", 2, 2, 0 );
+	final Spot a, aEnd, b, bEnd, c, a1, a2, b1, b2, c1, c2;
 
-	final Spot aEnd = addBranch( graph, a, 2 );
+	EmbryoA()
+	{
+		this( 0 );
+	}
 
-	final Spot a1 = addSpot( graph, aEnd, "A1", 2, 1, 0 );
-
-	final Spot a2 = addSpot( graph, aEnd, "A2", 2, 3, 0 );
-
-	final Spot b = addSpot( graph, null, "B", 4, 2, 0 );
-
-	final Spot bEnd = addBranch( graph, b, 3 );
-
-	final Spot b1 = addSpot( graph, bEnd, "B1", 4, 1, 0 );
-
-	final Spot b2 = addSpot( graph, bEnd, "B2", 4, 3, 0 );
-
-	final Spot c = addSpot( graph, null, "C", 4, 4, 0 );
-
-	final Spot c1 = addSpot( graph, c, "C1", 4, 4, 0 );
-
-	final Spot c2 = addSpot( graph, c, "C2", 4, 5, 0 );
+	EmbryoA( int startTime )
+	{
+		a = addSpot( graph, "A", startTime, 2, 2, 0 );
+		aEnd = addBranch( graph, a, 2 );
+		a1 = addSpot( graph, "A1", aEnd, 2, 1, 0 );
+		a2 = addSpot( graph, "A2", aEnd, 2, 3, 0 );
+		b = addSpot( graph, "B", startTime, 4, 2, 0 );
+		bEnd = addBranch( graph, b, 3 );
+		b1 = addSpot( graph, "B1", bEnd, 4, 1, 0 );
+		b2 = addSpot( graph, "B2", bEnd, 4, 3, 0 );
+		c = addSpot( graph, "C", startTime, 4, 4, 0 );
+		c1 = addSpot( graph, "C1", c, 4, 4, 0 );
+		c2 = addSpot( graph, "C2", c, 4, 5, 0 );
+	}
 
 	// helper methods
 
-	private static Spot addSpot( ModelGraph graph, Spot parent, String label, double... position )
+	private static Spot addSpot( ModelGraph graph, String label, int time, double... position )
 	{
-		int t = parent == null ? 0 : parent.getTimepoint() + 1;
-		Spot spot = graph.addVertex().init( t, position, 1 );
+		Spot spot = graph.addVertex().init( time, position, 1 );
 		spot.setLabel( label );
+		return spot;
+	}
+
+	static Spot addSpot( ModelGraph graph, String label, Spot parent, double... position )
+	{
+		int time = parent == null ? 2 : parent.getTimepoint() + 1;
+		Spot spot = addSpot( graph, label, time, position );
 		if ( parent != null )
 			graph.addEdge( parent, spot );
 		return spot;
 	}
 
-	private static Spot addBranch( ModelGraph graph, Spot branchStart, int length )
+	static Spot addBranch( ModelGraph graph, Spot branchStart, int length )
 	{
 		String label = branchStart.getLabel();
 		double[] position = { branchStart.getDoublePosition( 0 ), branchStart.getDoublePosition( 1 ), branchStart.getDoublePosition( 2 ) };
 		Spot s = branchStart;
 		for ( int i = 1; i < length; i++ )
-			s = addSpot( graph, s, label + "~" + i, position );
+			s = addSpot( graph, label + "~" + i, s, position );
 		return s;
 	}
 }

--- a/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/EmbryoB.java
+++ b/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/EmbryoB.java
@@ -12,8 +12,19 @@ import org.mastodon.mamut.model.Spot;
  */
 class EmbryoB extends EmbryoA
 {
+
+	public final AffineTransform3D transform;
+
 	EmbryoB()
 	{
+		this( 0 );
+	}
+
+	EmbryoB( int startTime )
+	{
+		super( startTime );
+		transform = new AffineTransform3D();
+		transform.rotate( 0, Math.PI / 2 );
 		transformSpotPositions();
 		flipB1andB2Positions();
 	}
@@ -21,8 +32,6 @@ class EmbryoB extends EmbryoA
 	private void transformSpotPositions()
 	{
 		// transform spot positions: rotate 90 degrees around x-axis
-		AffineTransform3D transform = new AffineTransform3D();
-		transform.rotate( 0, Math.PI / 2 );
 		for ( Spot spot : graph.vertices() )
 			transform.apply( spot, spot );
 	}

--- a/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/EmbryoBSingleCellStage.java
+++ b/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/EmbryoBSingleCellStage.java
@@ -1,0 +1,36 @@
+package org.mastodon.mamut.tomancak.lineage_registration;
+
+import org.mastodon.mamut.model.Spot;
+
+/**
+ * Example data for testing {@link LineageRegistrationAlgorithm} and {@link LineageRegistrationUtils}.
+ * The graph and coordinates are the similar to {@link EmbryoB}, but the graph in this class has
+ * additional spots abc, bc and beforeA, that are added to the graph before the first spots of {@link EmbryoB}.
+ * <p>
+ * {@link EmbryoBSingleCellStage#graph} has therefore only one root node: abc.
+ *
+ */
+class EmbryoBSingleCellStage extends EmbryoB
+{
+
+	Spot abc;
+
+	Spot bc;
+
+	Spot beforeA;
+
+	EmbryoBSingleCellStage()
+	{
+		super( 2 );
+		abc = graph.addVertex().init( 0, new double[] { 0, 0, 0 }, 1 );
+		bc = graph.addVertex().init( 1, new double[] { 1, 0, 0 }, 1 );
+		beforeA = graph.addVertex().init( 1, new double[] { 0, 0, 0 }, 1 );
+		beforeA.setLabel( "A" );
+		graph.addEdge( abc, bc );
+		graph.addEdge( abc, beforeA );
+		graph.addEdge( beforeA, a );
+		graph.addEdge( bc, b );
+		graph.addEdge( bc, c );
+	}
+
+}

--- a/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationAlgorithmTest.java
+++ b/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationAlgorithmTest.java
@@ -1,5 +1,6 @@
 package org.mastodon.mamut.tomancak.lineage_registration;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -7,6 +8,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import net.imglib2.realtransform.AffineTransform3D;
+
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mastodon.collection.RefRefMap;
 import org.mastodon.mamut.model.Spot;
@@ -14,26 +18,48 @@ import org.mastodon.mamut.model.Spot;
 public class LineageRegistrationAlgorithmTest
 {
 
+	List< String > expected = Arrays.asList(
+			"A -> A",
+			"A1 -> A1",
+			"A2 -> A2",
+			"B -> B",
+			"B1 -> B2",
+			"B2 -> B1",
+			"C -> C",
+			"C1 -> C1",
+			"C2 -> C2" );
+
 	@Test
 	public void testRun()
 	{
 		EmbryoA embryoA = new EmbryoA();
 		EmbryoB embryoB = new EmbryoB();
-		RegisteredGraphs result = LineageRegistrationAlgorithm.run( embryoA.graph, embryoB.graph );
-		List< String > strings = asString( result.mapAB );
-		assertEquals( Arrays.asList(
-				"A -> A",
-				"A1 -> A1",
-				"A2 -> A2",
-				"B -> B",
-				"B1 -> B2",
-				"B2 -> B1",
-				"C -> C",
-				"C1 -> C1",
-				"C2 -> C2" ), strings );
+		RegisteredGraphs result = LineageRegistrationAlgorithm.run( embryoA.graph, 0, embryoB.graph, 0 );
+		assertEquals( expected, asStrings( result.mapAB ) );
 	}
 
-	private static List< String > asString( RefRefMap< Spot, Spot > map )
+	@Ignore( "The estimation of the affine transform s" )
+	@Test
+	public void testDifferentlyStagedEmbryos()
+	{
+		EmbryoA embryoA = new EmbryoA();
+		EmbryoBSingleCellStage embryoB = new EmbryoBSingleCellStage();
+		RegisteredGraphs result = LineageRegistrationAlgorithm.run( embryoA.graph, 0, embryoB.graph, 2 );
+		assertEquals( expected, asStrings( result.mapAB ) );
+		assertEquals( embryoB.beforeA, result.mapAB.get( embryoA.a ) );
+		assertTransformEquals( embryoB.transform, result.transformAB );
+	}
+
+	private void assertTransformEquals( AffineTransform3D expected, AffineTransform3D actual )
+	{
+		double[] expectedValues = new double[ 12 ];
+		double[] actualValues = new double[ 12 ];
+		expected.toArray( expectedValues );
+		actual.toArray( actualValues );
+		assertArrayEquals( expectedValues, actualValues, 0.01 );
+	}
+
+	private static List< String > asStrings( RefRefMap< Spot, Spot > map )
 	{
 		List< String > strings = new ArrayList<>();
 		RefMapUtils.forEach( map, ( a, b ) -> strings.add( a.getLabel() + " -> " + b.getLabel() ) );

--- a/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationAlgorithmTest.java
+++ b/src/test/java/org/mastodon/mamut/tomancak/lineage_registration/LineageRegistrationAlgorithmTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import net.imglib2.realtransform.AffineTransform3D;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mastodon.collection.RefRefMap;
 import org.mastodon.mamut.model.Spot;
@@ -38,7 +37,6 @@ public class LineageRegistrationAlgorithmTest
 		assertEquals( expected, asStrings( result.mapAB ) );
 	}
 
-	@Ignore( "The estimation of the affine transform s" )
 	@Test
 	public void testDifferentlyStagedEmbryos()
 	{


### PR DESCRIPTION
Fixes #23 

The lineage registration dialog now has two text fields that allow to enter a starting time point. Spots before that timepoint are simply ignored by the algorithm ignore. This allow to for example compare an embryo tracking data that starts at a two cell stage with embryo tracking data that starts at a for cell stage.