### PR TITLE
git's current commit ID finger-printed into produced .jar file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,5 +129,48 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<version>4.9.10</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+					<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+					<includeOnlyProperties>
+						<includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+					</includeOnlyProperties>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<executable>sh</executable>
+					<arguments>
+						<argument>-c</argument>
+						<argument>rm -v '${project.build.outputDirectory}'/COMMITrev_*; touch '${project.build.outputDirectory}'/COMMITrev_${git.commit.id.abbrev}_${project.artifactId};</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -153,22 +153,23 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
 						<goals>
-							<goal>exec</goal>
+							<goal>run</goal>
 						</goals>
 					</execution>
 				</executions>
 				<configuration>
-					<executable>sh</executable>
-					<arguments>
-						<argument>-c</argument>
-						<argument>rm -v '${project.build.outputDirectory}'/COMMITrev_*; touch '${project.build.outputDirectory}'/COMMITrev_${git.commit.id.abbrev}_${project.artifactId};</argument>
-					</arguments>
+					<target>
+						<!-- make sure no COMMITrev tag files are floating around from some previous runs -->
+						<!-- NB: this task is redundant whenever 'mvn clean' is executed... -->
+						<delete><fileset dir="${project.build.outputDirectory}" includes="COMMITrev_*"/></delete>
+						<touch file="${project.build.outputDirectory}/COMMITrev_${git.commit.id.abbrev}_${project.artifactId}"/>
+					</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Hi,

having several Fiji.app folders around with variously configured Fijis, I keep finding "random" .jar files (that said, files storing some work-in-progress testing versions, not the official-update-site versions) from projects I'm working on... and I always ask myself what content is in these jars?

yes, I'm very infrequently updating the projects' versions, so all my `mastodon-tomancak` jars ATM are 0.3.2-SNAPSHOT ;-) ... which is anyway not too much informative

what I, however, do regularly keep updating is my git repo -- commit small, commit *often*, you know

And so in my other projects I have instructed maven to insert a "tag file" denoting the current "git rev id" into my jar files, which tailored to this project could look this:
![Screenshot_20230531_012152](https://github.com/mastodon-sc/mastodon-tomancak/assets/10509335/34b8790b-24a4-46b5-a0ad-d0345e0b3aee)

This is giving me a very good service because the "tag file" tells me, for example, what topic branch is hosted in this .jar file etc.

-----
The `_mastodon-tomancak` part of the "tag file" might seem redundant. It becomes useful when you create a fat .jar that consists of multiple projects, in which case several "tag files" may appear in the fat jar and there's a need to be able to distinguish among them...

