### PR TITLE
Add a menu entry sorting the TrachScheme with respect to cell lifetime

### DIFF
--- a/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
@@ -369,6 +369,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 			vertices = model.getGraph().vertices();
 
 		SortTree.sortCellLifetime( model, vertices );
+		appModel.getBranchGraphSync().sync();
 	}
 
 	private void showLineageView() {

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/CellLifetimeOrder.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/CellLifetimeOrder.java
@@ -13,13 +13,15 @@ import org.mastodon.mamut.tomancak.lineage_registration.BranchGraphUtils;
  * Compares the cell lifecycles of the two child cells of a given spot.
  * The child with the longer cell lifecycle is sorted to be the first child.
  * <pre>
- *          ┌─────┘─────┐                ┌─────┘─────┐
+ * {@code
+ *          ┌─────┴─────┐                ┌─────┴─────┐
  *          │2          │3               │3          │2
  *          │           │                │           │
- *       ┌──┘──┐        │       ==>      │        ┌──┘──┐
- *       │1    │2    ┌──┘──┐          ┌──┘──┐     │2    │1
+ *       ┌──┴──┐        │       ==>      │        ┌──┴──┐
+ *       │1    │2    ┌──┴──┐          ┌──┴──┐     │2    │1
  *             │     │2    │1         │2    │1    │
  *                   │                │
+ *}
  * </pre>
  */
 public class CellLifetimeOrder implements Predicate< Spot >

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/CellLifetimeOrder.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/CellLifetimeOrder.java
@@ -1,0 +1,55 @@
+package org.mastodon.mamut.tomancak.sort_tree;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.tomancak.lineage_registration.BranchGraphUtils;
+
+/**
+ * A sorting "order" for sorting the lineage tree in a {@link ModelGraph}.
+ * Compares the cell lifecycles of the two child cells of a given spot.
+ * The child with the longer cell lifecycle is sorted to be the first child.
+ */
+public class CellLifetimeOrder implements Predicate< Spot >
+{
+	private final ModelGraph graph;
+
+	public CellLifetimeOrder( ModelGraph graph )
+	{
+		this.graph = graph;
+	}
+
+	/**
+	 * Returns true if the cells are correctly sorted.
+	 */
+	@Override
+	public boolean test( Spot spot )
+	{
+		if ( spot.outgoingEdges().size() != 2 )
+			return true;
+
+		Spot ref1 = graph.vertexRef();
+		Spot ref2 = graph.vertexRef();
+		Spot ref3 = graph.vertexRef();
+		Spot ref4 = graph.vertexRef();
+		try
+		{
+			Iterator< Link > iterator = spot.outgoingEdges().iterator();
+			Spot child1 = iterator.next().getTarget( ref1 );
+			Spot child2 = iterator.next().getTarget( ref2 );
+			Spot end1 = BranchGraphUtils.getBranchEnd( child1, ref3 );
+			Spot end2 = BranchGraphUtils.getBranchEnd( child2, ref4 );
+			return end1.getTimepoint() >= end2.getTimepoint();
+		}
+		finally
+		{
+			graph.releaseRef( ref1 );
+			graph.releaseRef( ref2 );
+			graph.releaseRef( ref3 );
+			graph.releaseRef( ref4 );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/CellLifetimeOrder.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/CellLifetimeOrder.java
@@ -12,6 +12,15 @@ import org.mastodon.mamut.tomancak.lineage_registration.BranchGraphUtils;
  * A sorting "order" for sorting the lineage tree in a {@link ModelGraph}.
  * Compares the cell lifecycles of the two child cells of a given spot.
  * The child with the longer cell lifecycle is sorted to be the first child.
+ * <pre>
+ *          ┌─────┘─────┐                ┌─────┘─────┐
+ *          │2          │3               │3          │2
+ *          │           │                │           │
+ *       ┌──┘──┐        │       ==>      │        ┌──┘──┐
+ *       │1    │2    ┌──┘──┐          ┌──┘──┐     │2    │1
+ *             │     │2    │1         │2    │1    │
+ *                   │                │
+ * </pre>
  */
 public class CellLifetimeOrder implements Predicate< Spot >
 {

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
@@ -50,12 +50,12 @@ import java.util.function.Predicate;
 public class SortTree
 {
 
-	public static void sortLeftRightAnchors( Model model, Collection<Spot> vertices, Collection<Spot> leftAnchors, Collection<Spot> rightAnchors )
+	public static void sortLeftRightAnchors( Model model, Collection< Spot > vertices, Collection< Spot > leftAnchors, Collection< Spot > rightAnchors )
 	{
 		sort( model, vertices, new LeftRightOrder( model.getGraph(), leftAnchors, rightAnchors ) );
 	}
 
-	public static void sortExternIntern( Model model, Collection<Spot> vertices, Collection<Spot> centerSpots )
+	public static void sortExternIntern( Model model, Collection< Spot > vertices, Collection< Spot > centerSpots )
 	{
 		sort( model, vertices, new ExternInternOrder( model.getGraph(), centerSpots ) );
 	}
@@ -78,14 +78,14 @@ public class SortTree
 		sort( model, vertices, new CellLifetimeOrder( model.getGraph() ) );
 	}
 
-	public static void sort( Model model, Collection<Spot> vertices, Predicate<Spot> order )
+	public static void sort( Model model, Collection< Spot > vertices, Predicate< Spot > order )
 	{
 		ModelGraph graph = model.getGraph();
 		ReentrantReadWriteLock.WriteLock lock = graph.getLock().writeLock();
 		lock.lock();
 		try
 		{
-			RefList<Spot> toBeFlipped = findSpotsToBeFlipped( graph, vertices, order );
+			RefList< Spot > toBeFlipped = findSpotsToBeFlipped( graph, vertices, order );
 			FlipDescendants.flipDescendants( model, toBeFlipped );
 		}
 		finally
@@ -94,10 +94,10 @@ public class SortTree
 		}
 	}
 
-	private static RefList<Spot> findSpotsToBeFlipped( ModelGraph graph, Collection<Spot> vertices, Predicate<Spot> correctOrder )
+	private static RefList< Spot > findSpotsToBeFlipped( ModelGraph graph, Collection< Spot > vertices, Predicate< Spot > correctOrder )
 	{
-		RefList<Spot> toBeFlipped = new RefArrayList<>( graph.vertices().getRefPool() );
-		for(Spot spot : vertices )
+		RefList< Spot > toBeFlipped = new RefArrayList<>( graph.vertices().getRefPool() );
+		for ( Spot spot : vertices )
 		{
 			boolean needsToBeFlipped = spot.outgoingEdges().size() == 2
 					&& !correctOrder.test( spot );

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
@@ -67,11 +67,11 @@ public class SortTree
 	/**
 	 * Sorts the ModelGraph / TrackScheme, longer branches become the left (first) child.
 	 * <pre>
-	 *          ┌─────┘─────┐                ┌─────┘─────┐
+	 *          ┌─────┴─────┐                ┌─────┴─────┐
 	 *          │2          │3               │3          │2
 	 *          │           │                │           │
-	 *       ┌──┘──┐        │       ==>      │        ┌──┘──┐
-	 *       │1    │2    ┌──┘──┐          ┌──┘──┐     │2    │1
+	 *       ┌──┴──┐        │       ==>      │        ┌──┴──┐
+	 *       │1    │2    ┌──┴──┐          ┌──┴──┐     │2    │1
 	 *             │     │2    │1         │2    │1    │
 	 *                   │                │
 	 *</pre>

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
@@ -49,6 +49,10 @@ import java.util.function.Predicate;
  */
 public class SortTree
 {
+	private SortTree()
+	{
+		// prevent from instantiation
+	}
 
 	public static void sortLeftRightAnchors( Model model, Collection< Spot > vertices, Collection< Spot > leftAnchors, Collection< Spot > rightAnchors )
 	{

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
@@ -60,7 +60,20 @@ public class SortTree
 		sort( model, vertices, new ExternInternOrder( model.getGraph(), centerSpots ) );
 	}
 
-	public static void sortCellLifetime( Model model, Collection<Spot> vertices )
+	/**
+	 * Sorts the ModelGraph / TrackScheme, longer branches become the left (first) child.
+	 * <pre>
+	 *          ┌─────┘─────┐                ┌─────┘─────┐
+	 *          │2          │3               │3          │2
+	 *          │           │                │           │
+	 *       ┌──┘──┐        │       ==>      │        ┌──┘──┐
+	 *       │1    │2    ┌──┘──┐          ┌──┘──┐     │2    │1
+	 *             │     │2    │1         │2    │1    │
+	 *                   │                │
+	 *</pre>
+	 *
+	 */
+	public static void sortCellLifetime( Model model, Collection< Spot > vertices )
 	{
 		sort( model, vertices, new CellLifetimeOrder( model.getGraph() ) );
 	}

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
@@ -60,6 +60,11 @@ public class SortTree
 		sort( model, vertices, new ExternInternOrder( model.getGraph(), centerSpots ) );
 	}
 
+	public static void sortCellLifetime( Model model, Collection<Spot> vertices )
+	{
+		sort( model, vertices, new CellLifetimeOrder( model.getGraph() ) );
+	}
+
 	public static void sort( Model model, Collection<Spot> vertices, Predicate<Spot> order )
 	{
 		ModelGraph graph = model.getGraph();

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTree.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -67,6 +67,7 @@ public class SortTree
 	/**
 	 * Sorts the ModelGraph / TrackScheme, longer branches become the left (first) child.
 	 * <pre>
+	 * {@code
 	 *          ┌─────┴─────┐                ┌─────┴─────┐
 	 *          │2          │3               │3          │2
 	 *          │           │                │           │
@@ -74,6 +75,7 @@ public class SortTree
 	 *       │1    │2    ┌──┴──┐          ┌──┴──┐     │2    │1
 	 *             │     │2    │1         │2    │1    │
 	 *                   │                │
+	 *}
 	 *</pre>
 	 *
 	 */

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTreeExternInternDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTreeExternInternDialog.java
@@ -93,6 +93,7 @@ public class SortTreeExternInternDialog extends JDialog
 		Collection<Spot> center = centerLandmark.getSelectedSpots();
 		Collection<Spot> selectedSpots = nodesToSort.getSelectedSpots();
 		SortTree.sortExternIntern( appModel.getModel(), selectedSpots, center );
+		appModel.getBranchGraphSync().sync();
 	}
 
 	private static void centerWindow( Window frame) {

--- a/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTreeLeftRightDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/sort_tree/SortTreeLeftRightDialog.java
@@ -92,6 +92,7 @@ public class SortTreeLeftRightDialog extends JDialog
 		Collection<Spot> right = rightLandmark.getSelectedSpots();
 		Collection<Spot> selectedSpot = nodesToSort.getSelectedSpots();
 		SortTree.sortLeftRightAnchors( appModel.getModel(), selectedSpot, left, right );
+		appModel.getBranchGraphSync().sync();
 	}
 
 	private static void centerWindow(Window frame) {


### PR DESCRIPTION
fixes #25

There is a new menu entry in the mastodon menu:
`Plugins > Trees Management > Sort Lineage Tree (Cell Lifecycle Duration)` 

Clicking this entry will sort the TrackScheme which respect to the cell lifecycle duration. (Daughter cells are sorted. The daughter cell with the longer lifecycle will become the first daughter cell.)

Only the selected spots are sorted. If there are no spots selected, than the entire TrackScheme gets sorted.