### PR TITLE
Fix "File > Merge Two Projects..."

### DIFF
--- a/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
@@ -42,6 +42,7 @@ import javax.swing.JOptionPane;
 import org.mastodon.app.MastodonIcons;
 import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.mamut.KeyConfigScopes;
+import org.mastodon.mamut.MainWindow;
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.io.ProjectCreator;
 import org.mastodon.mamut.io.project.MamutImagePlusProject;
@@ -397,10 +398,14 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 
 				final Dataset dsA = new Dataset( pathA );
 				final Dataset dsB = new Dataset( pathB );
-				
+
 				final ProjectModel projectMerged = ProjectCreator.createProjectFromBdvFile( dsA.project().getDatasetXmlFile(), pluginAppModel.getContext() );
-				final MergeDatasets.OutputDataSet output = new MergeDatasets.OutputDataSet( projectMerged );
+				final MergeDatasets.OutputDataSet output = new MergeDatasets.OutputDataSet( projectMerged.getModel() );
 				MergeDatasets.merge( dsA, dsB, output, distCutoff, mahalanobisDistCutoff, ratioThreshold );
+
+				pluginAppModel.close(); // close currently open instance of Mastodon
+
+				new MainWindow( projectMerged ).setVisible( true ); // start a new instance of Mastodon that shows the result of the merge operation
 			}
 			catch( final Exception e )
 			{

--- a/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
@@ -402,10 +402,10 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 				final ProjectModel projectMerged = ProjectCreator.createProjectFromBdvFile( dsA.project().getDatasetXmlFile(), pluginAppModel.getContext() );
 				final MergeDatasets.OutputDataSet output = new MergeDatasets.OutputDataSet( projectMerged.getModel() );
 				MergeDatasets.merge( dsA, dsB, output, distCutoff, mahalanobisDistCutoff, ratioThreshold );
-
-				pluginAppModel.close(); // close currently open instance of Mastodon
-
-				new MainWindow( projectMerged ).setVisible( true ); // start a new instance of Mastodon that shows the result of the merge operation
+				// close currently open instance of Mastodon
+				pluginAppModel.close();
+				// start a new instance of Mastodon that shows the result of the merge operation
+				new MainWindow( projectMerged ).setVisible( true );
 			}
 			catch( final Exception e )
 			{

--- a/src/main/java/org/mastodon/mamut/tomancak/merging/Dataset.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/merging/Dataset.java
@@ -28,9 +28,6 @@
  */
 package org.mastodon.mamut.tomancak.merging;
 
-import static org.mastodon.mamut.tomancak.merging.MergingUtil.getMaxNonEmptyTimepoint;
-import static org.mastodon.mamut.tomancak.merging.MergingUtil.getNumTimepoints;
-
 import java.io.IOException;
 
 import org.mastodon.mamut.io.project.MamutProject;
@@ -47,8 +44,6 @@ public class Dataset
 {
 	private final MamutProject project;
 
-	private final int numTimepoints;
-
 	private final Model model;
 
 	private final int maxNonEmptyTimepoint;
@@ -56,15 +51,21 @@ public class Dataset
 	public Dataset( final String path ) throws IOException
 	{
 		project = MamutProjectIO.load( path );
-		numTimepoints = getNumTimepoints( project );
 		model = new Model();
 		try (final MamutProject.ProjectReader reader = project.openForReading())
 		{
 			model.loadRaw( reader );
 		}
-		maxNonEmptyTimepoint = getMaxNonEmptyTimepoint( model, numTimepoints );
-
+		maxNonEmptyTimepoint = maxTimepoint( model );
 		verify();
+	}
+
+	private int maxTimepoint( Model model )
+	{
+		int max = 0;
+		for ( Spot spot : model.getGraph().vertices() )
+			max = Math.max( max, spot.getTimepoint() );
+		return max;
 	}
 
 	public Model model()

--- a/src/main/java/org/mastodon/mamut/tomancak/merging/MergeDatasets.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/merging/MergeDatasets.java
@@ -38,6 +38,8 @@ import org.mastodon.mamut.model.Model;
 import org.mastodon.model.tag.TagSetStructure;
 import org.mastodon.model.tag.TagSetStructure.Tag;
 import org.mastodon.model.tag.TagSetStructure.TagSet;
+import org.mastodon.views.bdv.SharedBigDataViewerData;
+import org.scijava.Context;
 
 public class MergeDatasets
 {
@@ -45,7 +47,7 @@ public class MergeDatasets
 	{
 		private File datasetXmlFile;
 
-		private final ProjectModel model;
+		private final Model model;
 
 		private final TagSetStructure tagSetStructure;
 
@@ -55,9 +57,9 @@ public class MergeDatasets
 
 		private final TagSet labelConflictTagSet;
 
-		public OutputDataSet( final ProjectModel projectMerged )
+		public OutputDataSet( final Model model )
 		{
-			this.model = projectMerged;
+			this.model = model;
 			tagSetStructure = new TagSetStructure();
 			conflictTagSet = tagSetStructure.createTagSet( "Merge Conflict" );
 			tagConflictTagSet = tagSetStructure.createTagSet( "Merge Conflict (Tags)" );
@@ -70,53 +72,51 @@ public class MergeDatasets
 		}
 
 		/**
-		 * @param projectRoot
-		 *            where to store the new project
-		 * @throws IOException
-		 *             if an input/ouput problem occurs.
+		 * @param projectRoot where to store the new project
+		 * @throws IOException if an input/ouput problem occurs.
 		 */
-		public void saveProject( final File projectRoot ) throws IOException
+		public void saveProject( final Context context, final SharedBigDataViewerData sbd, final File projectRoot ) throws IOException
 		{
 			if ( datasetXmlFile == null )
 				throw new IllegalStateException();
 
 			// Make a new project model with the merged project, but pointing to the specified datasetXmlFile. 
 			final MamutProject project = new MamutProject( projectRoot, datasetXmlFile );
-			ProjectModel projectToSave = ProjectModel.create( model.getContext(), getModel(), model.getSharedBdvData(), project );
+			ProjectModel projectToSave = ProjectModel.create( context, getModel(), sbd, project );
 			ProjectSaver.saveProject( projectRoot, projectToSave );
 		}
 
 		public Model getModel()
 		{
-			return model.getModel();
+			return model;
 		}
 
 		public Tag addSourceTag( final String name, final int color )
 		{
 			final TagSet ts = tagSetStructure.createTagSet( "Merge Source " + name );
 			final Tag tag = ts.createTag( name, color );
-			model.getModel().getTagSetModel().setTagSetStructure( tagSetStructure );
+			model.getTagSetModel().setTagSetStructure( tagSetStructure );
 			return tag;
 		}
 
 		public Tag addConflictTag( final String name, final int color )
 		{
 			final Tag tag = conflictTagSet.createTag( name, color );
-			model.getModel().getTagSetModel().setTagSetStructure( tagSetStructure );
+			model.getTagSetModel().setTagSetStructure( tagSetStructure );
 			return tag;
 		}
 
 		public Tag addTagConflictTag( final String name, final int color )
 		{
 			final Tag tag = tagConflictTagSet.createTag( name, color );
-			model.getModel().getTagSetModel().setTagSetStructure( tagSetStructure );
+			model.getTagSetModel().setTagSetStructure( tagSetStructure );
 			return tag;
 		}
 
 		public Tag addLabelConflictTag( final String name, final int color )
 		{
 			final Tag tag = labelConflictTagSet.createTag( name, color );
-			model.getModel().getTagSetModel().setTagSetStructure( tagSetStructure );
+			model.getTagSetModel().setTagSetStructure( tagSetStructure );
 			return tag;
 		}
 
@@ -127,7 +127,7 @@ public class MergeDatasets
 
 		public void updateTagSetModel()
 		{
-			model.getModel().getTagSetModel().setTagSetStructure( tagSetStructure );
+			model.getTagSetModel().setTagSetStructure( tagSetStructure );
 		}
 	}
 

--- a/src/main/java/org/mastodon/mamut/tomancak/merging/MergingUtil.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/merging/MergingUtil.java
@@ -28,18 +28,9 @@
  */
 package org.mastodon.mamut.tomancak.merging;
 
-import org.mastodon.mamut.io.project.MamutProject;
-import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.model.SpotPool;
 import org.mastodon.properties.ObjPropertyMap;
-import org.mastodon.spatial.SpatialIndex;
-import org.mastodon.spatial.SpatioTemporalIndex;
-import org.mastodon.util.DummySpimData;
-
-import bdv.spimdata.SpimDataMinimal;
-import bdv.spimdata.XmlIoSpimDataMinimal;
-import mpicbg.spim.data.SpimDataException;
 
 public class MergingUtil
 {
@@ -57,61 +48,5 @@ public class MergingUtil
 		@SuppressWarnings( "unchecked" )
 		final ObjPropertyMap< Spot, String > labels = ( ObjPropertyMap< Spot, String > ) pool.labelProperty();
 		return labels.isSet( spot );
-	}
-
-	/**
-	 * Returns number of time-points in {@code project}. To to that, loads
-	 * {@code spimdata} for {@code project}.
-	 * 
-	 * @param project
-	 *            the project.
-	 * @return the number of time-points in the project.
-	 */
-	public static int getNumTimepoints( final MamutProject project )
-	{
-		try
-		{
-			final String spimDataXmlFilename = project.getDatasetXmlFile().getAbsolutePath();
-			SpimDataMinimal spimData = DummySpimData.tryCreate( project.getDatasetXmlFile().getName() );
-			if ( spimData == null )
-				spimData = new XmlIoSpimDataMinimal().load( spimDataXmlFilename );
-			return spimData.getSequenceDescription().getTimePoints().size();
-		}
-		catch ( final SpimDataException e )
-		{
-			throw new RuntimeException( e );
-		}
-	}
-
-	// Helper: max timepoint that has at least one spot
-
-	/**
-	 * Returns the largest timepoint (index) where model has a least one spot.
-	 * 
-	 * @param model
-	 *            the model.
-	 * @param numTimepoints
-	 *            the number of time-points in the model.
-	 * @return the largest timepoint (index) where model has a least one spot.
-	 */
-	public static int getMaxNonEmptyTimepoint( final Model model, final int numTimepoints )
-	{
-		int maxNonEmptyTimepoint = 0;
-		final SpatioTemporalIndex< Spot > spatioTemporalIndex = model.getSpatioTemporalIndex();
-		spatioTemporalIndex.readLock().lock();
-		try
-		{
-			for ( int t = 0; t < numTimepoints; ++t )
-			{
-				final SpatialIndex< Spot > index = spatioTemporalIndex.getSpatialIndex( t );
-				if ( index.size() > 0 )
-					maxNonEmptyTimepoint = t;
-			}
-		}
-		finally
-		{
-			spatioTemporalIndex.readLock().unlock();
-		}
-		return maxNonEmptyTimepoint;
 	}
 }


### PR DESCRIPTION
The Mastodon plugin "File > Merge Two Projects..." is broken since the changes of 1.0.0-27-SNAPSHOT.
The problem can be reproduced by installing Mastodon from the Mastodon-Dev update site and trying to use the "Merge Two Projects..." menu entry. The plugin will fail with in exception.

But there are actually two problems:

**1. Problem**
This line fails with an exception: https://github.com/mastodon-sc/mastodon-tomancak/blob/641411b81332b777027f3477435bf1808b09469d/src/main/java/org/mastodon/mamut/tomancak/merging/MergingUtil.java#L75

The method `tryCreate` was recently changed https://github.com/mastodon-sc/mastodon/commit/9f0f71c1691a8ec15b2f2383896cb3609b6fea02 and this code was never updated.

**1. Solution**

The code that calls `tryCreate` can be drastically simplified. There is no need to call the method anymore.

**2. Problem**

The code for showing the result of the merge operation was recently changed:
https://github.com/mastodon-sc/mastodon-tomancak/blob/641411b81332b777027f3477435bf1808b09469d/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java#L401-L403
with the consequence that the results of the merge operation are no longer shown to the user. The user has simply can not access the merged project.

**2. Solution** 
The "File > Merge Two Projects..." now closes the currently open Mastodon instance, and opens a new instance with the new merged project.