### PR TITLE
Move function merge two projects from Mastodon plugins menu to Fiji plugin menu

### DIFF
--- a/src/main/java/org/mastodon/mamut/tomancak/MergeTwoProjects.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/MergeTwoProjects.java
@@ -11,47 +11,47 @@ import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = Command.class, label = "Mastodon - Merge two mastodon projects into one project", menuPath = "Plugins > Tracking > Mastodon > Merge Two Projects" )
+@Plugin( type = Command.class, menuPath = "Plugins > Tracking > Mastodon > Merge Two Projects" )
 public class MergeTwoProjects implements Command
 {
 	@Parameter
 	private Context context;
 
+	private MergingDialog mergingDialog;
+
 	@Override
 	public void run()
 	{
-		mergeProjects();
+		if ( mergingDialog == null )
+		{
+			mergingDialog = new MergingDialog( null );
+			mergingDialog.onMerge( this::mergeProjects );
+		}
+		mergingDialog.setVisible( true );
 	}
-
-	private MergingDialog mergingDialog;
 
 	private void mergeProjects()
 	{
-		if ( mergingDialog == null )
-			mergingDialog = new MergingDialog( null );
-		mergingDialog.onMerge( () -> {
-			try
-			{
-				final String pathA = mergingDialog.getPathA();
-				final String pathB = mergingDialog.getPathB();
-				final double distCutoff = mergingDialog.getDistCutoff();
-				final double mahalanobisDistCutoff = mergingDialog.getMahalanobisDistCutoff();
-				final double ratioThreshold = mergingDialog.getRatioThreshold();
+		try
+		{
+			final String pathA = mergingDialog.getPathA();
+			final String pathB = mergingDialog.getPathB();
+			final double distCutoff = mergingDialog.getDistCutoff();
+			final double mahalanobisDistCutoff = mergingDialog.getMahalanobisDistCutoff();
+			final double ratioThreshold = mergingDialog.getRatioThreshold();
 
-				final Dataset dsA = new Dataset( pathA );
-				final Dataset dsB = new Dataset( pathB );
+			final Dataset dsA = new Dataset( pathA );
+			final Dataset dsB = new Dataset( pathB );
 
-				final ProjectModel projectMerged = ProjectCreator.createProjectFromBdvFile( dsA.project().getDatasetXmlFile(), context );
-				final MergeDatasets.OutputDataSet output = new MergeDatasets.OutputDataSet( projectMerged.getModel() );
-				MergeDatasets.merge( dsA, dsB, output, distCutoff, mahalanobisDistCutoff, ratioThreshold );
-				// start a new instance of Mastodon that shows the result of the merge operation
-				new MainWindow( projectMerged ).setVisible( true );
-			}
-			catch ( final Exception e )
-			{
-				e.printStackTrace();
-			}
-		} );
-		mergingDialog.setVisible( true );
+			final ProjectModel projectMerged = ProjectCreator.createProjectFromBdvFile( dsA.project().getDatasetXmlFile(), context );
+			final MergeDatasets.OutputDataSet output = new MergeDatasets.OutputDataSet( projectMerged.getModel() );
+			MergeDatasets.merge( dsA, dsB, output, distCutoff, mahalanobisDistCutoff, ratioThreshold );
+			// start a new instance of Mastodon that shows the result of the merge operation
+			new MainWindow( projectMerged ).setVisible( true );
+		}
+		catch ( final Exception e )
+		{
+			e.printStackTrace();
+		}
 	}
 }

--- a/src/main/java/org/mastodon/mamut/tomancak/MergeTwoProjects.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/MergeTwoProjects.java
@@ -1,0 +1,57 @@
+package org.mastodon.mamut.tomancak;
+
+import org.mastodon.mamut.MainWindow;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.ProjectCreator;
+import org.mastodon.mamut.tomancak.merging.Dataset;
+import org.mastodon.mamut.tomancak.merging.MergeDatasets;
+import org.mastodon.mamut.tomancak.merging.MergingDialog;
+import org.scijava.Context;
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = Command.class, label = "Mastodon - Merge two mastodon projects into one project", menuPath = "Plugins > Tracking > Mastodon > Merge Two Projects" )
+public class MergeTwoProjects implements Command
+{
+	@Parameter
+	private Context context;
+
+	@Override
+	public void run()
+	{
+		mergeProjects();
+	}
+
+	private MergingDialog mergingDialog;
+
+	private void mergeProjects()
+	{
+		if ( mergingDialog == null )
+			mergingDialog = new MergingDialog( null );
+		mergingDialog.onMerge( () -> {
+			try
+			{
+				final String pathA = mergingDialog.getPathA();
+				final String pathB = mergingDialog.getPathB();
+				final double distCutoff = mergingDialog.getDistCutoff();
+				final double mahalanobisDistCutoff = mergingDialog.getMahalanobisDistCutoff();
+				final double ratioThreshold = mergingDialog.getRatioThreshold();
+
+				final Dataset dsA = new Dataset( pathA );
+				final Dataset dsB = new Dataset( pathB );
+
+				final ProjectModel projectMerged = ProjectCreator.createProjectFromBdvFile( dsA.project().getDatasetXmlFile(), context );
+				final MergeDatasets.OutputDataSet output = new MergeDatasets.OutputDataSet( projectMerged.getModel() );
+				MergeDatasets.merge( dsA, dsB, output, distCutoff, mahalanobisDistCutoff, ratioThreshold );
+				// start a new instance of Mastodon that shows the result of the merge operation
+				new MainWindow( projectMerged ).setVisible( true );
+			}
+			catch ( final Exception e )
+			{
+				e.printStackTrace();
+			}
+		} );
+		mergingDialog.setVisible( true );
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/merging/MergingDialog.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/merging/MergingDialog.java
@@ -174,7 +174,7 @@ public class MergingDialog extends JDialog
 		buttons.add( okButton );
 		getContentPane().add( buttons, BorderLayout.SOUTH );
 
-		setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
+		setDefaultCloseOperation( WindowConstants.DISPOSE_ON_CLOSE );
 		addWindowListener( new WindowAdapter()
 		{
 			@Override
@@ -201,7 +201,6 @@ public class MergingDialog extends JDialog
 		am.put( hideKey, hideAction );
 
 		pack();
-		setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
 	}
 
 	private void cancel()


### PR DESCRIPTION
This PR implements the result of a discussion regarding re-arrangement of menu entries.

The menu entry `merge two projects` is moved from Mastodon plugins menu to Fiji plugin menu

* Reasoning: this method does not really touch the currently open Mastodon session but merges two projects outside of it

![grafik](https://github.com/user-attachments/assets/1b0bad84-1c78-4378-ab54-2800c8118eb8)

![grafik](https://github.com/user-attachments/assets/4b127830-b789-40ea-8070-00d9882b8382)
