### PR TITLE
Change short cut for the Fuse Spots command from ctrl shift f to ctrl alt f

### DIFF
--- a/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
@@ -125,7 +125,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String[] ADD_CENTER_SPOTS_KEYS = { "not mapped" };
 	private static final String[] MIRROR_SPOTS_KEYS = { "not mapped" };
 	private static final String[] CREATE_CONFLICT_TAG_SET_KEYS = { "not mapped" };
-	private static final String[] FUSE_SPOTS_KEYS = { "ctrl shift F" };
+
+	private static final String[] FUSE_SPOTS_KEYS = { "ctrl alt F" };
 	private static final String[] LOCATE_TAGS_KEYS = { "not mapped" };
 
 	private static final String[] CELL_DIVISIONS_TAG_SET_KEYS = { "not mapped" };

--- a/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
@@ -103,7 +103,6 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String CREATE_CONFLICT_TAG_SET = "[tomancak] create conflict tag set";
 	private static final String FUSE_SPOTS = "[tomancak] fuse selected spots";
 	private static final String LOCATE_TAGS = "[tomancak] locate tags";
-
 	private static final String CELL_DIVISIONS_TAG_SET = "[tomancak] create cell divisions tag set";
 
 	private static final String[] EXPORT_PHYLOXML_KEYS = { "not mapped" };
@@ -125,10 +124,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String[] ADD_CENTER_SPOTS_KEYS = { "not mapped" };
 	private static final String[] MIRROR_SPOTS_KEYS = { "not mapped" };
 	private static final String[] CREATE_CONFLICT_TAG_SET_KEYS = { "not mapped" };
-
 	private static final String[] FUSE_SPOTS_KEYS = { "ctrl alt F" };
 	private static final String[] LOCATE_TAGS_KEYS = { "not mapped" };
-
 	private static final String[] CELL_DIVISIONS_TAG_SET_KEYS = { "not mapped" };
 
 	private static Map< String, String > menuTexts = new HashMap<>();


### PR DESCRIPTION
* Reasoning ctrl shift f is now the default for the mastodon global command finder in the core