### PR TITLE
Create dummy tag set and set radius of selected spots

### DIFF
--- a/src/main/java/org/mastodon/mamut/tomancak/CreateDummyTagSet.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/CreateDummyTagSet.java
@@ -1,0 +1,112 @@
+package org.mastodon.mamut.tomancak;
+
+import java.awt.Color;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Random;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.model.tag.TagSetStructure;
+import org.mastodon.util.TagSetUtils;
+import org.scijava.Context;
+import org.scijava.ItemVisibility;
+import org.scijava.command.Command;
+import org.scijava.command.CommandService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateDummyTagSet
+{
+	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	private static final Random random = new Random();
+
+	private CreateDummyTagSet()
+	{
+		// Prevent instantiation.
+	}
+
+	static void createDummyTagSet( final ProjectModel projectModel, final CommandService commandService )
+	{
+		commandService.run( DummyTagSetCommand.class, true, "model", projectModel.getModel() );
+	}
+
+	@Plugin( type = Command.class, label = "Create dummy tag set" )
+	public static class DummyTagSetCommand implements Command
+	{
+
+		private static final int WIDTH = 15;
+
+		@SuppressWarnings( "all" )
+		@Parameter( visibility = ItemVisibility.MESSAGE, required = false, persist = false )
+		private String documentation = "<html>\n"
+				+ "<body width=" + WIDTH + "cm align=left>\n"
+				+ "<h2>Create a dummy tag set with a specifiable number of tags</h2>\n"
+				+ "<p>"
+				+ "This plugin generates a new tag set with a specifiable number of tags in random colors.<br><br>"
+				+ "Mastodon can handle tousands of tags, but the maximum number is limited by the system of the user.<br><br>"
+				+ "An error message while trying to create the tag set might indicate that the specified number of tags exceeds the maximum number the Mastodon installation can handle.<br>"
+				+ "</p>\n"
+				+ "</body>\n"
+				+ "</html>\n";
+
+		@Parameter
+		private Model model;
+
+		@Parameter
+		private Context context;
+
+		@Parameter( label = "Tag set name", description = "Specify the name of the tag set that should be generated." )
+		private String tagSetName;
+
+		@Parameter( label = "Maximum number of tags", description = "Specify the number tags that should be generated in a dummy tag set.", min = "0", stepSize = "1" )
+		private int maxTags;
+
+		@Override
+		public void run()
+		{
+			createTagSet( model, tagSetName, maxTags );
+		}
+
+		private static void createTagSet( final Model model, final String tagSetName, final int numTags )
+		{
+			logger.info( "Creating tag set '{}' with {} dummy tags...", tagSetName, numTags );
+			final ReentrantReadWriteLock lock = model.getGraph().getLock();
+			lock.writeLock().lock();
+			try
+			{
+				Collection< Pair< String, Integer > > labelColorPairs = new ArrayList<>();
+				for ( int i = 0; i < numTags; i++ )
+					labelColorPairs.add( Pair.of( "tag" + i, getRandomColor().getRGB() ) );
+
+				TagSetStructure.TagSet tagSet = TagSetUtils.addNewTagSetToModel( model, tagSetName, labelColorPairs );
+				model.setUndoPoint();
+
+				logger.info( "Successfully added tag set." );
+				logger.info( "Tag set name: {} ", tagSet.getName() );
+				logger.info( "Number of tags: {}", tagSet.getTags().size() );
+			}
+			finally
+			{
+				lock.writeLock().unlock();
+			}
+		}
+
+		private static Color getRandomColor()
+		{
+			// Generate random RGB values
+			int red = random.nextInt( 256 );
+			int green = random.nextInt( 256 );
+			int blue = random.nextInt( 256 );
+
+			// Create the color using the RGB values
+			return new Color( red, green, blue );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/SetRadiusSelectedSpots.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/SetRadiusSelectedSpots.java
@@ -1,0 +1,98 @@
+package org.mastodon.mamut.tomancak;
+
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import javax.swing.JOptionPane;
+
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.model.SelectionModel;
+import org.scijava.Context;
+import org.scijava.command.Command;
+import org.scijava.command.CommandService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+public class SetRadiusSelectedSpots
+{
+	private SetRadiusSelectedSpots()
+	{
+		// Private constructor to prevent instantiation.
+	}
+
+	static void setRadiusSelectedSpot( final ProjectModel projectModel, final CommandService commandService )
+	{
+		final SelectionModel< Spot, Link > selection = projectModel.getSelectionModel();
+		final Set< Spot > spots = selection.getSelectedVertices();
+		if ( spots.isEmpty() )
+			JOptionPane.showMessageDialog( null, "No spot selected.", "Set radius of selected spots", JOptionPane.WARNING_MESSAGE );
+		else
+			commandService.run( SetRadiusCommand.class, true, "projectModel", projectModel );
+	}
+
+	@Plugin( type = Command.class, label = "Set radius of selected spots" )
+	public static class SetRadiusCommand implements Command
+	{
+
+		@Parameter
+		private ProjectModel projectModel;
+
+		@Parameter
+		private Context context;
+
+		@Parameter( label = "Spot radius", description = "Specify the radius you want to set for the selected spots.", min = "0", validater = "validateRadius", initializer = "initRadius" )
+		private double radius;
+
+		@Override
+		public void run()
+		{
+			if ( radius <= 0 )
+				return;
+			final SelectionModel< Spot, Link > selection = projectModel.getSelectionModel();
+			final Model model = projectModel.getModel();
+			final ReentrantReadWriteLock lock = model.getGraph().getLock();
+			lock.writeLock().lock();
+
+			try
+			{
+				final Set< Spot > spots = selection.getSelectedVertices();
+				double[][] covariance = covarianceFromRadiusSquared( radius * radius );
+				spots.forEach( spot -> spot.setCovariance( covariance ) );
+				model.setUndoPoint();
+			}
+			finally
+			{
+				lock.writeLock().unlock();
+			}
+			model.getGraph().notifyGraphChanged();
+		}
+
+		@SuppressWarnings( "unused" )
+		private void validateRadius()
+		{
+			if ( radius <= 0 )
+				JOptionPane.showMessageDialog( null, "Selected radius must > 0.", "Non positive radius.",
+						JOptionPane.ERROR_MESSAGE );
+		}
+
+		@SuppressWarnings( "unused" )
+		private void initRadius()
+		{
+			if ( radius <= 0 )
+				radius = Math
+						.sqrt( projectModel.getSelectionModel().getSelectedVertices().iterator().next().getBoundingSphereRadiusSquared() );
+		}
+
+		private static double[][] covarianceFromRadiusSquared( final double radiusSquared )
+		{
+			final double[][] covariance = new double[ 3 ][ 3 ];
+			for ( int row = 0; row < 3; ++row )
+				for ( int col = 0; col < 3; ++col )
+					covariance[ row ][ col ] = ( row == col ) ? radiusSquared : 0;
+			return covariance;
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
@@ -82,6 +82,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String COPY_TAG = "[tomancak] copy tag";
 	private static final String INTERPOLATE_SPOTS = "[tomancak] interpolate missing spots";
 	private static final String LABEL_SELECTED_SPOTS = "[tomancak] label selected spots";
+
+	private static final String SET_RADIUS_SELECTED_SPOTS = "[tomancak] set radius selected spots";
 	private static final String CHANGE_BRANCH_LABELS = "[tomancak] change branch labels";
 	private static final String COMPACT_LINEAGE_VIEW = "[tomancak] show compact lineage";
 	private static final String SORT_TREE = "[tomancak] sort lineage tree";
@@ -105,6 +107,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String[] COPY_TAG_KEYS = { "not mapped" };
 	private static final String[] INTERPOLATE_SPOTS_KEYS = { "not mapped" };
 	private static final String[] LABEL_SELECTED_SPOTS_KEYS = { "F2" };
+
+	private static final String[] SET_RADIUS_SELECTED_SPOTS_KEYS = { "F3" };
 	private static final String[] CHANGE_BRANCH_LABELS_KEYS = { "shift F2" };
 	private static final String[] COMPACT_LINEAGE_VIEW_KEYS = { "not mapped" };
 	private static final String[] SORT_TREE_KEYS = { "ctrl S" };
@@ -132,6 +136,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		menuTexts.put( COPY_TAG, "Copy tag" );
 		menuTexts.put( INTERPOLATE_SPOTS, "Interpolate missing spots" );
 		menuTexts.put( LABEL_SELECTED_SPOTS, "Label selected spots" );
+		menuTexts.put( SET_RADIUS_SELECTED_SPOTS, "Set radius of selected spots" );
 		menuTexts.put( CHANGE_BRANCH_LABELS, "Change branch labels" );
 		menuTexts.put( COMPACT_LINEAGE_VIEW, "Show compact lineage" );
 		menuTexts.put( SORT_TREE, "Sort lineage tree (left-right-anchors)" );
@@ -169,6 +174,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 			descriptions.add( COPY_TAG, COPY_TAG_KEYS, "Copy tags: everything that has tag A assigned gets B assigned." );
 			descriptions.add( INTERPOLATE_SPOTS, INTERPOLATE_SPOTS_KEYS, "Along each track, new spot is inserted to every time points with no spots." );
 			descriptions.add( LABEL_SELECTED_SPOTS, LABEL_SELECTED_SPOTS_KEYS, "Set label for all selected spots." );
+			descriptions.add( SET_RADIUS_SELECTED_SPOTS, SET_RADIUS_SELECTED_SPOTS_KEYS, "Set radius for all selected spots." );
 			descriptions.add( CHANGE_BRANCH_LABELS, CHANGE_BRANCH_LABELS_KEYS, "Change the labels of all the spots between to division." );
 			descriptions.add( COMPACT_LINEAGE_VIEW, COMPACT_LINEAGE_VIEW_KEYS, "Show compact representation of the lineage tree.");
 			descriptions.add( SORT_TREE, SORT_TREE_KEYS, "Sort selected spots according to tagged anchors.");
@@ -202,6 +208,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private final AbstractNamedAction interpolateSpotsAction;
 
 	private final AbstractNamedAction labelSelectedSpotsAction;
+
+	private final AbstractNamedAction setRadiusSelectedSpotsAction;
 
 	private final AbstractNamedAction changeBranchLabelsAction;
 
@@ -246,6 +254,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		copyTagAction = new RunnableAction( COPY_TAG, this::copyTag );
 		interpolateSpotsAction = new RunnableAction( INTERPOLATE_SPOTS, this::interpolateSpots );
 		labelSelectedSpotsAction = new RunnableAction( LABEL_SELECTED_SPOTS, this::labelSelectedSpots );
+		setRadiusSelectedSpotsAction = new RunnableAction( SET_RADIUS_SELECTED_SPOTS, this::setRadiusSelectedSpots );
 		changeBranchLabelsAction = new RunnableAction( CHANGE_BRANCH_LABELS, this::changeBranchLabels );
 		lineageTreeViewAction = new RunnableAction( COMPACT_LINEAGE_VIEW, this::showLineageView );
 		sortTreeAction = new RunnableAction( SORT_TREE, this::sortTree );
@@ -296,7 +305,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 										item( MIRROR_SPOTS ),
 										item( REMOVE_SOLISTS_SPOTS ),
 										item( ADD_CENTER_SPOTS ),
-										item( INTERPOLATE_SPOTS ) ) ),
+										item( INTERPOLATE_SPOTS ),
+										item( SET_RADIUS_SELECTED_SPOTS ) ) ),
 						menu( "Trees management",
 								item( FLIP_DESCENDANTS ),
 								menu( "Conflict resolution",
@@ -324,6 +334,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		actions.namedAction( copyTagAction, COPY_TAG_KEYS );
 		actions.namedAction( interpolateSpotsAction, INTERPOLATE_SPOTS_KEYS );
 		actions.namedAction( labelSelectedSpotsAction, LABEL_SELECTED_SPOTS_KEYS );
+		actions.namedAction( setRadiusSelectedSpotsAction, SET_RADIUS_SELECTED_SPOTS_KEYS );
 		actions.namedAction( changeBranchLabelsAction, CHANGE_BRANCH_LABELS_KEYS );
 		actions.namedAction( lineageTreeViewAction, COMPACT_LINEAGE_VIEW_KEYS );
 		actions.namedAction( sortTreeAction, SORT_TREE_KEYS );
@@ -367,6 +378,11 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private void labelSelectedSpots()
 	{
 		LabelSelectedSpots.labelSelectedSpot( projectModel );
+	}
+
+	private void setRadiusSelectedSpots()
+	{
+		SetRadiusSelectedSpots.setRadiusSelectedSpot( projectModel, commandService );
 	}
 
 	private void sortTree() {

--- a/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
+++ b/src/main/java/org/mastodon/mamut/tomancak/TomancakPlugins.java
@@ -82,7 +82,6 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String COPY_TAG = "[tomancak] copy tag";
 	private static final String INTERPOLATE_SPOTS = "[tomancak] interpolate missing spots";
 	private static final String LABEL_SELECTED_SPOTS = "[tomancak] label selected spots";
-
 	private static final String SET_RADIUS_SELECTED_SPOTS = "[tomancak] set radius selected spots";
 	private static final String CHANGE_BRANCH_LABELS = "[tomancak] change branch labels";
 	private static final String COMPACT_LINEAGE_VIEW = "[tomancak] show compact lineage";
@@ -101,13 +100,13 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String FUSE_SPOTS = "[tomancak] fuse selected spots";
 	private static final String LOCATE_TAGS = "[tomancak] locate tags";
 	private static final String CELL_DIVISIONS_TAG_SET = "[tomancak] create cell divisions tag set";
+	private static final String CREATE_DUMMY_TAG_SET = "[tomancak] create dummy tag set";
 
 	private static final String[] EXPORT_PHYLOXML_KEYS = { "not mapped" };
 	private static final String[] FLIP_DESCENDANTS_KEYS = { "ctrl E" };
 	private static final String[] COPY_TAG_KEYS = { "not mapped" };
 	private static final String[] INTERPOLATE_SPOTS_KEYS = { "not mapped" };
 	private static final String[] LABEL_SELECTED_SPOTS_KEYS = { "F2" };
-
 	private static final String[] SET_RADIUS_SELECTED_SPOTS_KEYS = { "F3" };
 	private static final String[] CHANGE_BRANCH_LABELS_KEYS = { "shift F2" };
 	private static final String[] COMPACT_LINEAGE_VIEW_KEYS = { "not mapped" };
@@ -126,6 +125,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private static final String[] FUSE_SPOTS_KEYS = { "ctrl alt F" };
 	private static final String[] LOCATE_TAGS_KEYS = { "not mapped" };
 	private static final String[] CELL_DIVISIONS_TAG_SET_KEYS = { "not mapped" };
+	private static final String[] CREATE_DUMMY_TAG_SET_KEYS = { "not mapped" };
 
 	private static Map< String, String > menuTexts = new HashMap<>();
 
@@ -153,6 +153,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		menuTexts.put( FUSE_SPOTS, "Fuse selected spots" );
 		menuTexts.put( LOCATE_TAGS, "Locate tags" );
 		menuTexts.put( CELL_DIVISIONS_TAG_SET, "Add tag set to highlight cell divisions" );
+		menuTexts.put( CREATE_DUMMY_TAG_SET, "Create dummy tag set" );
 	}
 
 	/*
@@ -193,6 +194,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 			descriptions.add( FUSE_SPOTS, FUSE_SPOTS_KEYS, "Fuse selected spots into a single spot. Average spot position and shape." );
 			descriptions.add( LOCATE_TAGS, LOCATE_TAGS_KEYS, "Open a dialog that allows to jump to specific tags." );
 			descriptions.add( CELL_DIVISIONS_TAG_SET, CELL_DIVISIONS_TAG_SET_KEYS, "Adds a tag set to highlight cell divisions." );
+			descriptions.add( CREATE_DUMMY_TAG_SET, CREATE_DUMMY_TAG_SET_KEYS,
+					"Creates a dummy tag set with a specifiable maximum number of tags." );
 		}
 	}
 
@@ -245,6 +248,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 
 	private final AbstractNamedAction cellDivisionsTagSetAction;
 
+	private final AbstractNamedAction createDummyTagSet;
+
 	private ProjectModel projectModel;
 
 	public TomancakPlugins()
@@ -271,6 +276,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		fuseSpots = new RunnableAction( FUSE_SPOTS, this::fuseSpots );
 		locateTags = new RunnableAction( LOCATE_TAGS, this::locateTags );
 		cellDivisionsTagSetAction = new RunnableAction( CELL_DIVISIONS_TAG_SET, this::runCellDivisionsTagSet );
+		createDummyTagSet = new RunnableAction( CREATE_DUMMY_TAG_SET, this::createDummyTagSet );
 	}
 
 	@Override
@@ -295,7 +301,8 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 						menu( "Tags",
 								item( LOCATE_TAGS ),
 								item( COPY_TAG ),
-								item( CELL_DIVISIONS_TAG_SET ) ),
+								item( CELL_DIVISIONS_TAG_SET ),
+								item( CREATE_DUMMY_TAG_SET ) ),
 						menu( "Spots management",
 								menu( "Rename spots",
 										item( LABEL_SELECTED_SPOTS ),
@@ -351,6 +358,7 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 		actions.namedAction( fuseSpots, FUSE_SPOTS_KEYS );
 		actions.namedAction( locateTags, LOCATE_TAGS_KEYS );
 		actions.namedAction( cellDivisionsTagSetAction, CELL_DIVISIONS_TAG_SET_KEYS );
+		actions.namedAction( createDummyTagSet, CREATE_DUMMY_TAG_SET_KEYS );
 	}
 
 	private void exportPhyloXml()
@@ -475,5 +483,10 @@ public class TomancakPlugins extends AbstractContextual implements MamutPlugin
 	private void runCellDivisionsTagSet()
 	{
 		commandService.run( CellDivisionsTagSetCommand.class, true, "projectModel", projectModel );
+	}
+
+	private void createDummyTagSet()
+	{
+		CreateDummyTagSet.createDummyTagSet( projectModel, commandService );
 	}
 }


### PR DESCRIPTION
This PR adds 2 new plugins:

1. Create a dummy tag set with a specifiable number of tags in random colors

![GIF 28 11 2024 16-16-33](https://github.com/user-attachments/assets/d846b4c6-2ecc-4352-9793-8568964fe8fa)

2. Set the radius of all selected spots to a specifiable radius

![GIF 28 11 2024 16-14-28](https://github.com/user-attachments/assets/179436cf-43a6-438e-bc64-9dff0975f43f)