### PR TITLE
Bump dependencies: pom-scijava to 42.0.0 and mastodon to 1.0.0-beta-35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>40.0.0</version>
+        <version>42.0.0</version>
 	</parent>
 
 	<groupId>org.mastodon</groupId>
@@ -109,7 +109,7 @@
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Tobias Pietzsch</license.copyrightOwners>
 
-		<mastodon.version>1.0.0-beta-34</mastodon.version>
+        <mastodon.version>1.0.0-beta-35</mastodon.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>


### PR DESCRIPTION
This pull request updates dependency versions in the `pom.xml` file to keep the project up to date with the latest releases.

Dependency version updates:

* Updated the parent POM version from `40.0.0` to `42.0.0` to use the latest SciJava parent configuration.
* Updated the `mastodon.version` property from `1.0.0-beta-34` to `1.0.0-beta-35` to use the newest Mastodon release.